### PR TITLE
Add test coverage for non-v4 and invalid UUIDs and fix v4 APIs to behave as V2 APIs - accept non-v4 UUIDs

### DIFF
--- a/cla-backend-go/swagger/cla.v2.yaml
+++ b/cla-backend-go/swagger/cla.v2.yaml
@@ -892,11 +892,7 @@ paths:
   /project-compat/{projectID}:
     parameters:
       - $ref: "#/parameters/x-request-id"
-      - name: projectID
-        in: path
-        type: string
-        required: true
-        pattern: '^[a-fA-F0-9]{8}-?[a-fA-F0-9]{4}-?4[a-fA-F0-9]{3}-?[89ab][a-fA-F0-9]{3}-?[a-fA-F0-9]{12}$' # uuidv4
+      - $ref: "#/parameters/projectPathUuid"
     get:
       summary: Get project by ID (returns data in the same format as Py V2 API)
       security: [ ]
@@ -2448,12 +2444,7 @@ paths:
   /user/{userID}/active-signature:
     parameters:
       - $ref: "#/parameters/x-request-id"
-      - name: userID
-        description: the user ID
-        in: path
-        type: string
-        required: true
-        pattern: '^[a-fA-F0-9]{8}-?[a-fA-F0-9]{4}-?4[a-fA-F0-9]{3}-?[89ab][a-fA-F0-9]{3}-?[a-fA-F0-9]{12}$' # uuidv4
+      - $ref: "#/parameters/userPathUuid"
     get:
       summary: |
         Returns all metadata associated with a user's active signature.
@@ -4525,6 +4516,20 @@ responses:
 
 # Common parameters
 parameters:
+  userPathUuid:
+    name: userID
+    in: path
+    required: true
+    description: The user ID (UUID string)
+    type: string
+    pattern: '^[a-fA-F0-9]{8}-?[a-fA-F0-9]{4}-?[a-fA-F0-9]{4}-?[a-fA-F0-9]{4}-?[a-fA-F0-9]{12}$' # this is any UUID, not only v4
+  projectPathUuid:
+    name: projectID
+    in: path
+    required: true
+    description: The project ID (UUID string)
+    type: string
+    pattern: '^[a-fA-F0-9]{8}-?[a-fA-F0-9]{4}-?[a-fA-F0-9]{4}-?[a-fA-F0-9]{4}-?[a-fA-F0-9]{12}$' # this is any UUID, not only v4
   pageSize:
     name: pageSize
     description: The maximum number of results per page, value must be a positive integer value

--- a/cla-backend-go/swagger/common/project-compat.yaml
+++ b/cla-backend-go/swagger/common/project-compat.yaml
@@ -8,8 +8,7 @@ description: Project Model - in Py V2 - minimal fields needed by FE
 properties:
   project_id:
     description: Project's UUID
-    example: '88ee12de-122b-4c46-9046-19422054ed8d'
-    type: string
+    $ref: './common/properties/uuid.yaml'
     x-omitempty: false
   project_name:
     description: Project name
@@ -78,8 +77,7 @@ properties:
       properties:
         cla_group_id:
           description: Project's UUID
-          example: '88ee12de-122b-4c46-9046-19422054ed8d'
-          type: string
+          $ref: './common/properties/uuid.yaml'
           x-omitempty: false
         foundation_sfid:
           description: The salesforce foundation ID

--- a/cla-backend-go/swagger/common/properties/uuid.yaml
+++ b/cla-backend-go/swagger/common/properties/uuid.yaml
@@ -1,0 +1,6 @@
+# Copyright The Linux Foundation and each contributor to CommunityBridge.
+# SPDX-License-Identifier: MIT
+
+type: string
+example: 'a1b86c26-d8e8-4fd8-9f8d-5c723d5dac9f'
+pattern: '^[a-fA-F0-9]{8}-?[a-fA-F0-9]{4}-?[a-fA-F0-9]{4}-?[a-fA-F0-9]{4}-?[a-fA-F0-9]{12}$'

--- a/cla-backend-go/swagger/common/user-active-signature.yaml
+++ b/cla-backend-go/swagger/common/user-active-signature.yaml
@@ -9,10 +9,10 @@ description: >
   Returns `null` if the user does not have an active signature.
 properties:
   user_id:
-    $ref: './common/properties/internal-id.yaml'
+    $ref: './common/properties/uuid.yaml'
     description: The unique internal UUID of the user
   project_id:
-    $ref: './common/properties/internal-id.yaml'
+    $ref: './common/properties/uuid.yaml'
     description: The unique UUID of the associated project
   repository_id:
     type: string
@@ -24,7 +24,7 @@ properties:
     example: '456'
   merge_request_id:
     type: string
-    description: The merge request ID related to the signature (optional number stored as string, thsi property can be missing in JSON)
+    description: The merge request ID related to the signature (optional number stored as string, this property can be missing in JSON)
     example: '456'
     x-nullable: true
   return_url:

--- a/cla-backend-go/v2/sign/handlers.go
+++ b/cla-backend-go/v2/sign/handlers.go
@@ -278,7 +278,6 @@ func Configure(api *operations.EasyclaAPI, service Service, userService users.Se
 			}
 			return sign.NewGetUserActiveSignatureOK().WithPayload(resp)
 		})
-
 }
 
 type codedResponse interface {

--- a/tests/py2go/README.md
+++ b/tests/py2go/README.md
@@ -24,4 +24,8 @@
 - `` DEBUG='' USER_UUID=b817eb57-045a-4fe0-8473-fbb416a01d70 PY_API_URL=https://api.lfcla.dev.platform.linuxfoundation.org go test -v -run '^TestUserActiveSignatureAPI$' ``.
 - `` REPO_ID=466156917 PR_ID=3 DEBUG=1 go test -v -run '^TestUserActiveSignatureAPI$' ``.
 - `` MAX_PARALLEL=2 DEBUG='' go test -v -run '^TestAllUserActiveSignatureAPI$' ``.
-- `` [STAGE=prod PROD=1] REMOTE=1 make ``.
+- `` [STAGE=prod] [PY_API_URL=local|dev|prod] [GO_API_URL=local|dev|prod] make ``.
+- `` GO_API_URL=dev PY_API_URL=dev go test -v -run '^TestUserActiveSignatureAPIWithNonV4UUID$' ``.
+- `` GO_API_URL=dev PY_API_URL=dev go test -v -run '^TestUserActiveSignatureAPIWithInvalidUUID$' ``.
+- `` GO_API_URL=dev PY_API_URL=dev go test -v -run '^TestProjectCompatAPIWithNonV4UUID$' ``.
+- `` GO_API_URL=dev PY_API_URL=dev go test -v -run '^TestProjectCompatAPIWithInvalidUUID$' ``.


### PR DESCRIPTION
Refactored UUID validation to use reusable, general UUID patterns (not v4-only) across Swagger definitions.
Added tests for invalid and non-v4 UUIDs with exact response checks.
Simplified test config and improved debug output.

cc @mlehotskylf - this fixes the issue that we've seen yesterday during KT call.
