### PR TITLE
Add support for patterns matching empty or missing properties: login, email, name

### DIFF
--- a/cla-backend-go/github/bots.go
+++ b/cla-backend-go/github/bots.go
@@ -16,6 +16,7 @@ import (
 
 // propertyMatches returns true if value matches the pattern.
 // - "*" matches anything
+// - "" matches empty value
 // - "re:..." matches regex (value must be non-empty)
 // - otherwise, exact match
 func propertyMatches(pattern, value string) bool {
@@ -25,6 +26,9 @@ func propertyMatches(pattern, value string) bool {
 		"value":        value,
 	}
 	if pattern == "*" {
+		return true
+	}
+	if pattern == "" && value == "" {
 		return true
 	}
 	if value == "" {
@@ -54,12 +58,12 @@ func stripOrg(repoFull string) string {
 
 // isActorSkipped returns true if the actor should be skipped according to ANY pattern in config.
 // Each config entry is "<login_pattern>;<email_pattern>;<name_pattern>"
-// Any missing pattern defaults to "*"
+// Any missing pattern defaults to "" which is special and matches missing property, null property value or empty string property value
 func isActorSkipped(actor *UserCommitSummary, config []string) bool {
 	for _, pattern := range config {
 		parts := strings.Split(pattern, ";")
 		for len(parts) < 3 {
-			parts = append(parts, "*")
+			parts = append(parts, "")
 		}
 		loginPattern, emailPattern, namePattern := parts[0], parts[1], parts[2]
 
@@ -143,9 +147,10 @@ func parseConfigPatterns(config string) []string {
 //   - repo-name is the exact repository name under given org (e.g., "my-repo" not "my-org/my-repo")
 //   - re:repo-regexp is a regex pattern to match repository names
 //   - * is a wildcard that applies to all repositories
-//   - <login_pattern> is a GitHub login pattern (exact match or regex prefixed by re: or match all '*')
-//   - <email_pattern> is a GitHub email pattern (exact match or regex prefixed by re: or match all '*') if not specified defaults to '*'
-//   - <name_pattern> is a GitHub name pattern (exact match or regex prefixed by re: or match all '*') if not specified defaults to '*'
+//   - <login_pattern> is a GitHub login pattern (exact match or regex prefixed by re: or match all '*') if not specified defaults to ”
+//   - <email_pattern> is a GitHub email pattern (exact match or regex prefixed by re: or match all '*') if not specified defaults to ”
+//   - <name_pattern> is a GitHub name pattern (exact match or regex prefixed by re: or match all '*') if not specified defaults to ”
+//     ” matches empty value, null value or missing property
 //     The login, email and name patterns are separated by a semicolon (;). Email and name parts are optional.
 //     There can be an array of patterns for a single repository, separated by ||. It must start with a '[' and end with a ']': "[...||...||...]"
 //     If the skip_cla is not set, it will skip the allowlisted bots check.

--- a/cla-backend-go/github/bots.go
+++ b/cla-backend-go/github/bots.go
@@ -147,10 +147,10 @@ func parseConfigPatterns(config string) []string {
 //   - repo-name is the exact repository name under given org (e.g., "my-repo" not "my-org/my-repo")
 //   - re:repo-regexp is a regex pattern to match repository names
 //   - * is a wildcard that applies to all repositories
-//   - <login_pattern> is a GitHub login pattern (exact match or regex prefixed by re: or match all '*') if not specified defaults to ”
-//   - <email_pattern> is a GitHub email pattern (exact match or regex prefixed by re: or match all '*') if not specified defaults to ”
-//   - <name_pattern> is a GitHub name pattern (exact match or regex prefixed by re: or match all '*') if not specified defaults to ”
-//     ” matches empty value, null value or missing property
+//   - <login_pattern> is a GitHub login pattern (exact match or regex prefixed by re: or match all '*') if not specified defaults to ""
+//   - <email_pattern> is a GitHub email pattern (exact match or regex prefixed by re: or match all '*') if not specified defaults to ""
+//   - <name_pattern> is a GitHub name pattern (exact match or regex prefixed by re: or match all '*') if not specified defaults to ""
+//     "" matches empty value, null value or missing property
 //     The login, email and name patterns are separated by a semicolon (;). Email and name parts are optional.
 //     There can be an array of patterns for a single repository, separated by ||. It must start with a '[' and end with a ']': "[...||...||...]"
 //     If the skip_cla is not set, it will skip the allowlisted bots check.

--- a/cla-backend-go/swagger/common/github-organization.yaml
+++ b/cla-backend-go/swagger/common/github-organization.yaml
@@ -93,9 +93,10 @@ properties:
       - "login;*;*"
       - "login;email@domain.com;Real Name"
     example:
-      "*": "some-bot-login;*;*"
-      "repo1": "re:vee?rendra;*;*"
-      "re:(?i)^repo[0-9]+$": "[re:(?i)^l(ukasz)?gryglicki$;re:(?i)^l(ukasz)?gryglicki@;*||;re:^\d+\+Copilot@users\.noreply\.github\.com$;copilot-swe-agent[bot]]"
+      '*': 'some-bot-login;*;*'
+      'repo1': 're:vee?rendra;*;*'
+      're:(?i)^repo[0-9]+$': '[re:(?i)^l(ukasz)?gryglicki$;re:(?i)^l(ukasz)?gryglicki@;*||;re:^\d+\+Copilot@users\.noreply\.github\.com$;copilot-swe-agent[bot]]'
+
   repositories:
     type: object
     properties:

--- a/cla-backend-go/swagger/common/github-organization.yaml
+++ b/cla-backend-go/swagger/common/github-organization.yaml
@@ -77,24 +77,25 @@ properties:
       Map of repository name or pattern (e.g. 'repo1', '*', 're:pattern') to a string or array-string of pattern entries for skipping CLA checks for certain bots.
 
       Each value can be either:
-      - A string in the form '<login_pattern>;<email_pattern>;<name_pattern>' (email and name patterns are optional, default to '*').
+      - A string in the form '<login_pattern>;<email_pattern>;<name_pattern>' (email and name patterns are optional, default to '').
       - Or an OR-array in the form '[<entry1>||<entry2>||...]', where each entry uses the same pattern format above.
 
       Patterns can be:
       - An exact match (e.g. 'repo1', 'login', 'Name Surname', 'email@domain').
+      - A special case of exact match is '' pattern - it matches empty string, null property value or missing property.
       - A regular expression prefixed with 're:' (e.g. 're:(?i)^bot.*$').
       - A wildcard '*' to match all.
 
       Example formats:
-      - "copilot-swe-agent[bot];*;*"
+      - ";*;copilot-swe-agent[bot]"
       - "re:vee?rendra;*;*"
       - "[re:(?i)^l(ukasz)?gryglicki$;re:(?i)^l(ukasz)?gryglicki@;*||copilot-swe-agent[bot]]"
-      - "login;*"
+      - "login;*;*"
       - "login;email@domain.com;Real Name"
     example:
-      "*": "copilot-swe-agent[bot];*;*"
+      "*": "some-bot-login;*;*"
       "repo1": "re:vee?rendra;*;*"
-      "re:(?i)^repo[0-9]+$": "[re:(?i)^l(ukasz)?gryglicki$;re:(?i)^l(ukasz)?gryglicki@;*||copilot-swe-agent[bot]]"
+      "re:(?i)^repo[0-9]+$": "[re:(?i)^l(ukasz)?gryglicki$;re:(?i)^l(ukasz)?gryglicki@;*||;re:^\d+\+Copilot@users\.noreply\.github\.com$;copilot-swe-agent[bot]]"
   repositories:
     type: object
     properties:

--- a/cla-backend/cla/models/github_models.py
+++ b/cla-backend/cla/models/github_models.py
@@ -932,11 +932,14 @@ class GitHub(repository_service_interface.RepositoryService):
         """
         Returns True if value matches the pattern.
         - '*' matches anything
+        - '' matches None or empty string
         - 're:...' matches regex - value must be set
         - otherwise, exact match
         """
         try:
             if pattern == '*':
+                return True
+            if pattern == '' and (value is None or value == ''):
                 return True
             if value is None or value == '':
                 return False
@@ -952,7 +955,7 @@ class GitHub(repository_service_interface.RepositoryService):
         """
         Returns True if the actor should be skipped (allowlisted) based on config pattern.
         config: '<login_pattern>;<email_pattern>;<name_pattern>'
-        If any pattern is missing, it defaults to '*'
+        If any pattern is missing, it defaults to '' which is special and matches None or empty string.
         It returns true if ANY config entry matches or false if there is no match in any config entry.
         """
         try:
@@ -965,7 +968,7 @@ class GitHub(repository_service_interface.RepositoryService):
             # Otherwise, treat as string pattern
             parts = config.split(';')
             while len(parts) < 3:
-                parts.append('*')
+                parts.append('')
             login_pattern, email_pattern, name_pattern = parts[:3]
             login = getattr(actor, "author_login", None)
             email = getattr(actor, "author_email", None)
@@ -1028,9 +1031,10 @@ class GitHub(repository_service_interface.RepositoryService):
         - repo-name is the exact repository name under given org (e.g., "my-repo" not "my-org/my-repo")
         - re:repo-regexp is a regex pattern to match repository names
         - * is a wildcard that applies to all repositories
-        - <login_pattern> is a GitHub login pattern (exact match or regex prefixed by re: or match all '*')
-        - <email_pattern> is a GitHub email pattern (exact match or regex prefixed by re: or match all '*') - defaults to '*' if not set
-        - <name_pattern> is a GitHub name pattern (exact match or regex prefixed by re: or match all '*') - defaults to '*' if not set
+        - <login_pattern> is a GitHub login pattern (exact match or regex prefixed by re: or match all '*') - defaults to '' if not set
+        - <email_pattern> is a GitHub email pattern (exact match or regex prefixed by re: or match all '*') - defaults to '' if not set
+        - <name_pattern> is a GitHub name pattern (exact match or regex prefixed by re: or match all '*') - defaults to '' if not set
+        :note: '' is a special pattern that matches None or empty string.
         :note: The login (sometimes called username it's the same), email and name patterns are separated by a semicolon (;).
         :note: There can be an array of patterns - it must start with [ and with ] and be || separated.
         :note: If the skip_cla is not set, it will skip the allowlisted bots check.

--- a/utils/skip_cla_entry.sh
+++ b/utils/skip_cla_entry.sh
@@ -11,6 +11,7 @@
 # ./utils/scan.sh github-orgs organization_name sun-test-org
 # STAGE=dev DTFROM='1 hour ago' DTTO='1 second ago' ./utils/search_aws_log_group.sh 'cla-backend-dev-githubactivity' 'skip_cla'
 # MODE=delete-key ./utils/skip_cla_entry.sh 'sun-test-org' 're:(?i)^repo[0-9]+$'
+# STAGE=dev MODE=add-key DEBUG=1 ./utils/skip_cla_entry.sh 'sun-test-org' 'repo1' 'thakurveerendras;;*'
 # STAGE=prod MODE=add-key DEBUG=1 ./utils/skip_cla_entry.sh 'open-telemetry' 'opentelemetry-rust' '*;re:^\d+\+Copilot@users\.noreply\.github\.com$;copilot-swe-agent[bot]'
 
 if [ -z "$MODE" ]


### PR DESCRIPTION
Adds support for skipping login or email or name on additional condition - `""` (empty) - that means that pattern matches when given property is not set, is null of is empty string.

Why? Because GitHub bots have no login (they only have email like `<num>+Copilot@users.noreply.github.com` and name `copilot-swe-agent[bot]`.

To deal with that we had to set login pattern to `*` (meaning allow all) which theoretically allows any Github login with email like one I’ve described and name = `'copilot-swe-agent[bot]'` to skip CLA.

If GitHub is not sending login for those bots then there must be a pattern that matches EXACTLY that.

I'm using `""` (empty string), so the pattern would be `;email_pattern;name_pattern` - that way it is more secure.

cc @mlehotskylf @ahmedomosanya 