### PR TITLE
Record the GitHub account a contributor signs a CLA as

### DIFF
--- a/cla-backend-go/cmd/server.go
+++ b/cla-backend-go/cmd/server.go
@@ -438,7 +438,7 @@ func server(localMode bool) http.Handler {
 	gitlabOrganizationsService := gitlab_organizations.NewService(gitlabOrganizationRepo, v2RepositoriesService, v1ProjectClaGroupRepo, storeRepository, usersService, signaturesRepo, v1CompanyRepo)
 	v1SignaturesService := signatures.NewService(signaturesRepo, v1CompanyService, usersService, eventsService, githubOrgValidation, v1RepositoriesService, githubOrganizationsService, v1ProjectService, gitlabApp, configFile.ClaV1ApiURL, configFile.CLALandingPage, configFile.CLALogoURL)
 	v2SignatureService := v2Signatures.NewService(awsSession, configFile.SignatureFilesBucket, v1ProjectService, v1CompanyService, v1SignaturesService, v1ProjectClaGroupRepo, signaturesRepo, usersService, approvalsRepo)
-	v2MyClasService := v2MyClas.NewService(v2MyClas.NewRepository(awsSession, stage), user_service.GetClient(), v1SignaturesService, v1CompanyRepo, v1ProjectClaGroupRepo, project_service.GetClient())
+	v2MyClasService := v2MyClas.NewService(v2MyClas.NewRepository(awsSession, stage), user_service.GetClient(), v1SignaturesService, v1CompanyRepo, v1ProjectClaGroupRepo, project_service.GetClient(), usersService)
 	v1ClaManagerService := cla_manager.NewService(claManagerReqRepo, v1ProjectClaGroupRepo, v1CompanyService, v1ProjectService, usersService, v1SignaturesService, eventsService, emailTemplateService, configFile.CorporateConsoleV2URL)
 	v2ClaManagerService := v2ClaManager.NewService(emailTemplateService, v1CompanyService, v1ProjectService, v1ClaManagerService, usersService, v1RepositoriesService, v2CompanyService, eventsService, v1ProjectClaGroupRepo)
 	v1ApprovalListService := approval_list.NewService(approvalListRepo, v1ProjectClaGroupRepo, v1ProjectService, usersRepo, v1CompanyRepo, v1CLAGroupRepo, signaturesRepo, emailTemplateService, configFile.CorporateConsoleV2URL, http.DefaultClient)
@@ -998,6 +998,16 @@ func createUserFromRequest(authorizer auth.Authorizer, usersService users.Servic
 	f["claUserLFUsername"] = claUser.LFUsername
 	f["claUserLFEmail"] = claUser.LFEmail
 	f["claUserEmails"] = strings.Join(claUser.Emails, ",")
+
+	// Carry the token-verified caller on every request rather than under the path gate
+	// below. That gate decides whether the *user record* is injected for
+	// /v4/user-from-token; this is the caller's own identity as the token stated it, which
+	// the signing-identity endpoint needs in order to write against the right person and
+	// to notice if the gateway authenticated somebody else.
+	//
+	// Assigned to r before the lookups below so that every one of this function's early
+	// returns carries it - several of them return without reaching the end.
+	r = r.WithContext(user.ContextWithVerifiedCaller(r.Context(), claUser))
 
 	// only needed if API called is /v4/user-from-token
 	needToStoreUser := r.URL.Path == "/v4/user-from-token"

--- a/cla-backend-go/swagger/cla.v2.yaml
+++ b/cla-backend-go/swagger/cla.v2.yaml
@@ -2862,6 +2862,56 @@ paths:
       tags:
         - my_clas
 
+  /my-clas/signing-identity:
+    post:
+      summary: Confirm And Record The Signing GitHub Identity
+      description: >
+        Records the GitHub account the contributor selected against their EasyCLA user
+        record, and returns that record's identifier for the CLA hand-off to consume.
+        The submitted githubId is taken on trust: ownership is established by the calling
+        service from the accounts the identity provider reports the contributor has
+        linked, and this endpoint verifies the caller rather than the account. What it
+        does check is that recording the account is safe given the records that already
+        exist - a contested account, a duplicated one, a record already holding a
+        different account, or a record naming nobody are all refused rather than
+        resolved. Resolution keys on the GitHub account number before the LF identity,
+        because the authentication middleware may have created an LF-only record moments
+        earlier on this same request. Every refusal writes nothing, except
+        recorded_mismatch, which is raised only after the write when the record cannot be
+        read back holding the submitted account, and does not undo it.
+      operationId: bindSigningIdentity
+      parameters:
+        - $ref: "#/parameters/x-request-id"
+        - $ref: "#/parameters/x-acl"
+        - $ref: "#/parameters/x-username"
+        - $ref: "#/parameters/x-email"
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/signing-identity-request'
+      responses:
+        '200':
+          description: 'Success'
+          headers:
+            x-request-id:
+              type: string
+              description: The unique request ID value - assigned/set by the API Gateway based on the session
+          schema:
+            $ref: '#/definitions/signing-identity'
+        '400':
+          $ref: '#/responses/invalid-request'
+        '401':
+          $ref: '#/responses/unauthorized'
+        '403':
+          $ref: '#/responses/forbidden'
+        '409':
+          $ref: '#/responses/conflict'
+        '500':
+          $ref: '#/responses/internal-server-error'
+      tags:
+        - my_clas
+
   /user/{userID}/request-company-admin:
     post:
       summary: Request Manager
@@ -5066,6 +5116,12 @@ definitions:
 
   my-identity-list:
     $ref: './common/my-identity-list.yaml'
+
+  signing-identity:
+    $ref: './common/signing-identity.yaml'
+
+  signing-identity-request:
+    $ref: './common/signing-identity-request.yaml'
 
   #--------------------------------------
   # Docusign Webhook Payload

--- a/cla-backend-go/swagger/common/signing-identity-request.yaml
+++ b/cla-backend-go/swagger/common/signing-identity-request.yaml
@@ -1,0 +1,28 @@
+# Copyright The Linux Foundation and each contributor to CommunityBridge.
+# SPDX-License-Identifier: MIT
+
+type: object
+x-nullable: false
+title: Signing Identity Request
+description: The GitHub account the contributor selected to sign with
+required:
+  - githubId
+properties:
+  githubId:
+    type: integer
+    format: int64
+    minimum: 1
+    description: >
+      The GitHub account number the contributor selected. Taken on trust: this service
+      does not establish that the account belongs to the caller. Ownership is established
+      by the calling service, which offers the contributor only the accounts the identity
+      provider reports they have linked. What is checked here is whether recording the
+      account is safe given the records that already exist.
+    example: 26589865
+  githubUsername:
+    type: string
+    description: >
+      The GitHub handle for the selected account. Display only and never matched on, but
+      recorded because approval lists written against handles cannot match a record
+      without one. Sent by the caller because the handle is not derivable here.
+    example: "octocat"

--- a/cla-backend-go/swagger/common/signing-identity.yaml
+++ b/cla-backend-go/swagger/common/signing-identity.yaml
@@ -1,0 +1,37 @@
+# Copyright The Linux Foundation and each contributor to CommunityBridge.
+# SPDX-License-Identifier: MIT
+
+type: object
+x-nullable: false
+title: Signing Identity
+description: The EasyCLA user record the confirmed GitHub account is associated with
+required:
+  - userId
+  - githubId
+properties:
+  userId:
+    type: string
+    description: The EasyCLA user record identifier the CLA hand-off consumes
+    example: "f1a2b3c4-1234-5678-90ab-cdef12345678"
+  githubId:
+    type: integer
+    format: int64
+    description: >
+      The GitHub account actually recorded on the user record, echoed so the caller can
+      check for itself that what was recorded is what the contributor chose. That is a
+      different question from whether the write succeeded, and only the caller - which
+      knows what was on screen - can answer it.
+    example: 26589865
+  githubUsername:
+    type: string
+    description: The recorded GitHub handle. Display only - never matched on.
+    example: "octocat"
+  outcome:
+    type: string
+    enum:
+      - matched
+      - created
+      - adopted
+    description: >
+      Which resolution path was taken. Observability only; not behavioural for the caller.
+    example: "matched"

--- a/cla-backend-go/user/user.go
+++ b/cla-backend-go/user/user.go
@@ -3,6 +3,31 @@
 
 package user
 
+import "context"
+
+type contextKey string
+
+// verifiedCallerKey carries the caller as their verified token stated them, from the
+// authentication middleware to the handlers. It is request-scoped and never persisted
+// or cached.
+const verifiedCallerKey contextKey = "verified-cla-user"
+
+// ContextWithVerifiedCaller returns a context carrying the caller parsed from their
+// verified token.
+func ContextWithVerifiedCaller(ctx context.Context, claUser *CLAUser) context.Context {
+	return context.WithValue(ctx, verifiedCallerKey, claUser)
+}
+
+// VerifiedCallerFromContext returns the caller placed on the context by the
+// authentication middleware, or nil when the request did not carry a verifiable token.
+func VerifiedCallerFromContext(ctx context.Context) *CLAUser {
+	claUser, ok := ctx.Value(verifiedCallerKey).(*CLAUser)
+	if !ok {
+		return nil
+	}
+	return claUser
+}
+
 // CLAUser data model
 type CLAUser struct {
 	UserID         string

--- a/cla-backend-go/v2/my_clas/handlers.go
+++ b/cla-backend-go/v2/my_clas/handlers.go
@@ -5,18 +5,23 @@ package my_clas
 
 import (
 	"context"
+	"errors"
+	"strings"
 
 	"github.com/LF-Engineering/lfx-kit/auth"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/linuxfoundation/easycla/cla-backend-go/gen/v2/restapi/operations"
 	myClasOps "github.com/linuxfoundation/easycla/cla-backend-go/gen/v2/restapi/operations/my_clas"
 	log "github.com/linuxfoundation/easycla/cla-backend-go/logging"
+	"github.com/linuxfoundation/easycla/cla-backend-go/user"
 	"github.com/linuxfoundation/easycla/cla-backend-go/utils"
 	"github.com/sirupsen/logrus"
 )
 
 const missingUsernameMsg = "the authenticated principal carries no username - unable to determine whose CLAs to look up"
 const missingIdentityMsg = "no identity provided - provide at least one of lfUsername, email, secondaryEmail, githubId, githubUsername, gitlabId, gitlabUsername, gerritUsername"
+const missingGithubIDMsg = "no githubId provided - provide the GitHub account number the contributor selected"
+const mismatchedIdentityMsg = "the gateway-authenticated principal and the token's LF identity disagree - refusing rather than recording an account against either"
 
 // Configure sets up the My CLAs API handlers
 func Configure(api *operations.EasyclaAPI, service Service) {
@@ -120,6 +125,70 @@ func Configure(api *operations.EasyclaAPI, service Service) {
 			}
 
 			return myClasOps.NewGetMyIdentitiesOK().WithXRequestID(reqID).WithPayload(result)
+		})
+
+	api.MyClasBindSigningIdentityHandler = myClasOps.BindSigningIdentityHandlerFunc(
+		func(params myClasOps.BindSigningIdentityParams, authUser *auth.User) middleware.Responder {
+			reqID := utils.GetRequestID(params.XREQUESTID)
+			ctx := context.WithValue(params.HTTPRequest.Context(), utils.XREQUESTID, reqID) // nolint
+			utils.SetAuthUserProperties(authUser, params.XUSERNAME, params.XEMAIL)
+			f := logrus.Fields{
+				"functionName":   "v2.my_clas.handlers.BindSigningIdentity",
+				utils.XREQUESTID: ctx.Value(utils.XREQUESTID),
+				"authUserName":   utils.StringValue(params.XUSERNAME),
+				"authUserEmail":  utils.StringValue(params.XEMAIL),
+			}
+
+			currentUsername, _ := principal(authUser)
+			if currentUsername == "" {
+				log.WithFields(f).Warn(missingUsernameMsg)
+				return myClasOps.NewBindSigningIdentityUnauthorized().WithXRequestID(reqID).WithPayload(utils.ErrorResponseUnauthorized(reqID, missingUsernameMsg))
+			}
+
+			// Two identities arrive on this request from two places: the one the gateway
+			// authenticated and injected, and the one the token carries. Everything below
+			// writes using the token's - so if they ever disagree, this endpoint would
+			// record the submitted GitHub account against whichever person the gateway did
+			// not authenticate. With the account number itself taken on trust, this
+			// identity is the only part of the write that anything actually verified, which
+			// is why a disagreement has to stop the request rather than be logged.
+			if caller := user.VerifiedCallerFromContext(ctx); caller != nil && caller.LFUsername != "" && !strings.EqualFold(caller.LFUsername, currentUsername) {
+				f["tokenLFUsername"] = caller.LFUsername
+				f["refusalReason"] = ReasonIdentityMismatch
+				log.WithFields(f).Warn(mismatchedIdentityMsg)
+				return myClasOps.NewBindSigningIdentityForbidden().WithXRequestID(reqID).WithPayload(utils.ErrorResponseForbidden(reqID, ReasonIdentityMismatch))
+			}
+
+			if params.Body.GithubID == nil {
+				log.WithFields(f).Warn(missingGithubIDMsg)
+				return myClasOps.NewBindSigningIdentityBadRequest().WithXRequestID(reqID).WithPayload(utils.ErrorResponseBadRequest(reqID, missingGithubIDMsg))
+			}
+
+			result, err := service.BindSigningIdentity(ctx, *params.Body.GithubID, params.Body.GithubUsername)
+			if err != nil {
+				// Refusals are mapped one code at a time rather than collapsed into a
+				// single failure response. The contributor's next step differs per reason
+				// - sign in again, choose again, or contact support - and an operator
+				// cannot tell an unauthenticated caller from a contested record through
+				// an undifferentiated failure.
+				var refusal *Refusal
+				if errors.As(err, &refusal) {
+					f["refusalReason"] = refusal.Reason
+					log.WithFields(f).Warn("refused to record the signing GitHub identity")
+					switch refusal.Reason {
+					case ReasonIdentityUnavailable:
+						return myClasOps.NewBindSigningIdentityForbidden().WithXRequestID(reqID).WithPayload(utils.ErrorResponseForbiddenWithError(reqID, refusal.Reason, refusal))
+					default:
+						return myClasOps.NewBindSigningIdentityConflict().WithXRequestID(reqID).WithPayload(utils.ErrorResponseConflictWithError(reqID, refusal.Reason, refusal))
+					}
+				}
+
+				msg := "unable to record the signing GitHub identity"
+				log.WithFields(f).WithError(err).Warn(msg)
+				return myClasOps.NewBindSigningIdentityInternalServerError().WithXRequestID(reqID).WithPayload(utils.ErrorResponseInternalServerErrorWithError(reqID, msg, err))
+			}
+
+			return myClasOps.NewBindSigningIdentityOK().WithXRequestID(reqID).WithPayload(result)
 		})
 }
 

--- a/cla-backend-go/v2/my_clas/handlers_test.go
+++ b/cla-backend-go/v2/my_clas/handlers_test.go
@@ -1,0 +1,209 @@
+// Copyright The Linux Foundation and each contributor to CommunityBridge.
+// SPDX-License-Identifier: MIT
+
+package my_clas
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/LF-Engineering/lfx-kit/auth"
+	"github.com/go-openapi/runtime"
+	v2Models "github.com/linuxfoundation/easycla/cla-backend-go/gen/v2/models"
+	"github.com/linuxfoundation/easycla/cla-backend-go/gen/v2/restapi/operations"
+	myClasOps "github.com/linuxfoundation/easycla/cla-backend-go/gen/v2/restapi/operations/my_clas"
+	"github.com/linuxfoundation/easycla/cla-backend-go/user"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resolvedUserID stands for whatever record the service settled on. The handler never
+// derives it, so its value carries no meaning beyond being echoed back.
+const resolvedUserID = "user-1"
+
+// stubService answers the binding call with whatever the test configures, so the handler's
+// status and reason-code mapping can be exercised without a repository.
+type stubService struct {
+	result *v2Models.SigningIdentity
+	err    error
+	// gotGithubUsername records what the handler forwarded, so a handler that drops the
+	// handle is caught here rather than surfacing later as an approval list that matches
+	// nothing.
+	gotGithubUsername string
+}
+
+func (s *stubService) GetMyClas(context.Context, string, bool, *Identity) (*v2Models.MyClaList, error) {
+	return nil, nil
+}
+
+func (s *stubService) GetMyClaPdfURL(context.Context, string, bool, *Identity, string) (*v2Models.MyClaPdf, error) {
+	return nil, nil
+}
+
+func (s *stubService) GetMyIdentities(context.Context, string) (*v2Models.MyIdentityList, error) {
+	return nil, nil
+}
+
+func (s *stubService) BindSigningIdentity(_ context.Context, _ int64, githubUsername string) (*v2Models.SigningIdentity, error) {
+	s.gotGithubUsername = githubUsername
+	return s.result, s.err
+}
+
+func bindResponse(t *testing.T, svc Service, githubID *int64, username string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	api := &operations.EasyclaAPI{}
+	Configure(api, svc)
+	require.NotNil(t, api.MyClasBindSigningIdentityHandler)
+
+	params := myClasOps.BindSigningIdentityParams{
+		HTTPRequest: httptest.NewRequest(http.MethodPost, "/v4/my-clas/signing-identity", nil),
+		Body:        v2Models.SigningIdentityRequest{GithubID: githubID, GithubUsername: chosenGithubUsername},
+	}
+
+	responder := api.MyClasBindSigningIdentityHandler.Handle(params, &auth.User{UserName: username})
+
+	recorder := httptest.NewRecorder()
+	responder.WriteResponse(recorder, runtime.JSONProducer())
+	return recorder
+}
+
+// bindResponseWithTokenIdentity issues the same request with a verified caller on the
+// context, so the two identities the handler sees can be made to disagree.
+func bindResponseWithTokenIdentity(t *testing.T, svc Service, githubID *int64, gatewayUsername, tokenUsername string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	api := &operations.EasyclaAPI{}
+	Configure(api, svc)
+	require.NotNil(t, api.MyClasBindSigningIdentityHandler)
+
+	request := httptest.NewRequest(http.MethodPost, "/v4/my-clas/signing-identity", nil)
+	request = request.WithContext(user.ContextWithVerifiedCaller(request.Context(), &user.CLAUser{
+		LFUsername: tokenUsername,
+	}))
+
+	responder := api.MyClasBindSigningIdentityHandler.Handle(myClasOps.BindSigningIdentityParams{
+		HTTPRequest: request,
+		Body:        v2Models.SigningIdentityRequest{GithubID: githubID, GithubUsername: chosenGithubUsername},
+	}, &auth.User{UserName: gatewayUsername})
+
+	recorder := httptest.NewRecorder()
+	responder.WriteResponse(recorder, runtime.JSONProducer())
+	return recorder
+}
+
+func TestBindSigningIdentityHandler_DisagreeingIdentitiesAreRefused(t *testing.T) {
+	githubID := chosenGithubID
+	userID := resolvedUserID
+	svc := &stubService{result: &v2Models.SigningIdentity{UserID: &userID, GithubID: &githubID, Outcome: outcomeMatched}}
+
+	recorder := bindResponseWithTokenIdentity(t, svc, &githubID, callerLFUsername, "someone-else")
+
+	// The write uses the token's identity, so proceeding here would record the submitted
+	// account against whichever person the gateway did not authenticate. With the account
+	// itself taken on trust, this identity is the only verified part of the write.
+	assert.Equal(t, http.StatusForbidden, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), ReasonIdentityMismatch)
+}
+
+func TestBindSigningIdentityHandler_AgreeingIdentitiesProceed(t *testing.T) {
+	githubID := chosenGithubID
+	userID := resolvedUserID
+	svc := &stubService{result: &v2Models.SigningIdentity{UserID: &userID, GithubID: &githubID, Outcome: outcomeMatched}}
+
+	// Case differences come from different sources normalising differently, and are not a
+	// disagreement about who is calling.
+	recorder := bindResponseWithTokenIdentity(t, svc, &githubID, callerLFUsername, strings.ToUpper(callerLFUsername))
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+}
+
+func TestBindSigningIdentityHandler_RefusalStatusMapping(t *testing.T) {
+	githubID := chosenGithubID
+
+	// Each refusal gets its own status because the contributor's next step differs:
+	// forbidden means the caller was not identified, conflict means the data needs a human
+	// before anything can be signed.
+	cases := []struct {
+		reason string
+		status int
+	}{
+		{ReasonIdentityUnavailable, http.StatusForbidden},
+		{ReasonRecordConflict, http.StatusConflict},
+		{ReasonRecordUnclaimed, http.StatusConflict},
+		{ReasonDuplicateGithubID, http.StatusConflict},
+		{ReasonLFRecordAlreadyBound, http.StatusConflict},
+		{ReasonRecordedMismatch, http.StatusConflict},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.reason, func(t *testing.T) {
+			svc := &stubService{err: refuse(testCase.reason, "refused")}
+
+			recorder := bindResponse(t, svc, &githubID, callerLFUsername)
+
+			assert.Equal(t, testCase.status, recorder.Code)
+			// The reason has to reach the caller, not just the log - the BFF routes on it.
+			assert.Contains(t, recorder.Body.String(), testCase.reason)
+		})
+	}
+}
+
+func TestBindSigningIdentityHandler_MissingGithubIDIsABadRequest(t *testing.T) {
+	recorder := bindResponse(t, &stubService{}, nil, callerLFUsername)
+
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+}
+
+func TestBindSigningIdentityHandler_NoPrincipalIsUnauthorized(t *testing.T) {
+	githubID := chosenGithubID
+
+	recorder := bindResponse(t, &stubService{}, &githubID, "")
+
+	assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+}
+
+func TestBindSigningIdentityHandler_UnexpectedErrorIsAServerError(t *testing.T) {
+	githubID := chosenGithubID
+	svc := &stubService{err: errors.New("dynamodb unavailable")}
+
+	recorder := bindResponse(t, svc, &githubID, callerLFUsername)
+
+	// An infrastructure failure must not be dressed up as a refusal: a refusal means a
+	// decision was reached, and counting one as the other corrupts the refusal counts.
+	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+}
+
+func TestBindSigningIdentityHandler_SuccessReturnsTheResolvedRecord(t *testing.T) {
+	githubID := chosenGithubID
+	userID := resolvedUserID
+	svc := &stubService{result: &v2Models.SigningIdentity{
+		UserID:   &userID,
+		GithubID: &githubID,
+		Outcome:  outcomeMatched,
+	}}
+
+	recorder := bindResponse(t, svc, &githubID, callerLFUsername)
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), userID)
+	// Echoed so the caller can check for itself that what was recorded is what was chosen.
+	assert.Contains(t, recorder.Body.String(), "87654321")
+}
+
+// The handle is the only field on this request the service cannot derive for itself, and
+// dropping it costs nothing visible at signing time - it surfaces much later, as an
+// approval list written against a handle that matches no record.
+func TestBindSigningIdentityHandler_ForwardsTheSubmittedHandle(t *testing.T) {
+	githubID := chosenGithubID
+	userID := resolvedUserID
+	svc := &stubService{result: &v2Models.SigningIdentity{UserID: &userID, GithubID: &githubID, Outcome: outcomeMatched}}
+
+	bindResponse(t, svc, &githubID, callerLFUsername)
+
+	assert.Equal(t, chosenGithubUsername, svc.gotGithubUsername)
+}

--- a/cla-backend-go/v2/my_clas/repository.go
+++ b/cla-backend-go/v2/my_clas/repository.go
@@ -31,6 +31,7 @@ type Repository interface {
 	GetUsersByGitlabID(ctx context.Context, gitlabID int64) ([]*v1Models.User, error)
 	GetUsersByGitlabUsername(ctx context.Context, gitlabUsername string) ([]*v1Models.User, error)
 	GetUsersBySecondaryEmails(ctx context.Context, emails []string) ([]*v1Models.User, error)
+	GetUserByIDConsistent(ctx context.Context, userID string) (*v1Models.User, error)
 }
 
 type repository struct {
@@ -185,6 +186,54 @@ func (repo repository) GetUsersBySecondaryEmails(ctx context.Context, emails []s
 	}
 
 	return toUserModels(dbUsers), nil
+}
+
+// GetUserByIDConsistent reads one user record by its primary key with a strongly
+// consistent read.
+//
+// Every other lookup here goes through a global secondary index, which is only ever
+// eventually consistent. That is fine for reading, and wrong for confirming a write: a
+// stale read after a successful write looks identical to the write having recorded the
+// wrong thing, and the caller cannot tell the two apart. Confirming on the base table with
+// ConsistentRead set removes the ambiguity, so a mismatch means a real mismatch.
+func (repo repository) GetUserByIDConsistent(ctx context.Context, userID string) (*v1Models.User, error) {
+	f := logrus.Fields{
+		"functionName":   "v2.my_clas.repository.GetUserByIDConsistent",
+		utils.XREQUESTID: ctx.Value(utils.XREQUESTID),
+		"userID":         userID,
+	}
+
+	expr, err := expression.NewBuilder().
+		WithKeyCondition(expression.Key("user_id").Equal(expression.Value(userID))).
+		Build()
+	if err != nil {
+		log.WithFields(f).WithError(err).Warn("error building expression for consistent user read")
+		return nil, err
+	}
+
+	queryResults, err := repo.dynamoDBClient.QueryWithContext(ctx, &dynamodb.QueryInput{
+		ExpressionAttributeNames:  expr.Names(),
+		ExpressionAttributeValues: expr.Values(),
+		KeyConditionExpression:    expr.KeyCondition(),
+		TableName:                 aws.String(repo.usersTableName),
+		ConsistentRead:            aws.Bool(true),
+	})
+	if err != nil {
+		log.WithFields(f).WithError(err).Warn("error reading user record by ID")
+		return nil, err
+	}
+
+	var dbUsers []users.DBUser
+	if unmarshalErr := dynamodbattribute.UnmarshalListOfMaps(queryResults.Items, &dbUsers); unmarshalErr != nil {
+		log.WithFields(f).WithError(unmarshalErr).Warn("error unmarshalling user record")
+		return nil, unmarshalErr
+	}
+
+	if len(dbUsers) == 0 {
+		return nil, nil
+	}
+
+	return toUserModels(dbUsers)[0], nil
 }
 
 func (repo repository) queryUsers(ctx context.Context, indexName string, condition expression.KeyConditionBuilder) ([]*v1Models.User, error) {

--- a/cla-backend-go/v2/my_clas/service.go
+++ b/cla-backend-go/v2/my_clas/service.go
@@ -93,6 +93,7 @@ type Service interface {
 	GetMyClas(ctx context.Context, currentUsername string, admin bool, requested *Identity) (*models.MyClaList, error)
 	GetMyClaPdfURL(ctx context.Context, currentUsername string, admin bool, requested *Identity, signatureID string) (*models.MyClaPdf, error)
 	GetMyIdentities(ctx context.Context, currentUsername string) (*models.MyIdentityList, error)
+	BindSigningIdentity(ctx context.Context, githubID int64, githubUsername string) (*models.SigningIdentity, error)
 }
 
 type service struct {
@@ -102,12 +103,13 @@ type service struct {
 	companyRepo           CompanyRepository
 	projectsClaGroupsRepo ProjectsCLAGroupsRepository
 	projectService        ProjectService
+	usersWriter           UsersWriter
 	presign               func(filename string) (string, error)
 	documentExists        func(filename string) (bool, error)
 }
 
 // NewService creates a new instance of the My CLAs service
-func NewService(repo Repository, platformUsersService PlatformUsersService, signaturesService SignaturesService, companyRepo CompanyRepository, projectsClaGroupsRepo ProjectsCLAGroupsRepository, projectService ProjectService) Service {
+func NewService(repo Repository, platformUsersService PlatformUsersService, signaturesService SignaturesService, companyRepo CompanyRepository, projectsClaGroupsRepo ProjectsCLAGroupsRepository, projectService ProjectService, usersWriter UsersWriter) Service {
 	return &service{
 		repo:                  repo,
 		platformUsersService:  platformUsersService,
@@ -115,6 +117,7 @@ func NewService(repo Repository, platformUsersService PlatformUsersService, sign
 		companyRepo:           companyRepo,
 		projectsClaGroupsRepo: projectsClaGroupsRepo,
 		projectService:        projectService,
+		usersWriter:           usersWriter,
 		presign:               utils.GetDownloadLink,
 		documentExists:        utils.DocumentExists,
 	}

--- a/cla-backend-go/v2/my_clas/service_test.go
+++ b/cla-backend-go/v2/my_clas/service_test.go
@@ -30,6 +30,10 @@ type fakeRepo struct {
 	byGitlabUsername map[string][]*v1Models.User
 	bySecondaryEmail map[string][]*v1Models.User
 	secondaryScans   int
+	// consistentRead serves the post-write confirmation. Tests that write leave it wired
+	// to the writer's own store (see newBindingService), so the confirmation sees what was
+	// actually written rather than a second copy that could drift from it.
+	consistentRead func(userID string) (*v1Models.User, error)
 }
 
 func (f *fakeRepo) GetUserCLASignatures(_ context.Context, userID string) ([]*signatures.ItemSignature, error) {
@@ -58,6 +62,13 @@ func (f *fakeRepo) GetUsersByGitlabID(_ context.Context, gitlabID int64) ([]*v1M
 
 func (f *fakeRepo) GetUsersByGitlabUsername(_ context.Context, gitlabUsername string) ([]*v1Models.User, error) {
 	return f.byGitlabUsername[gitlabUsername], nil
+}
+
+func (f *fakeRepo) GetUserByIDConsistent(_ context.Context, userID string) (*v1Models.User, error) {
+	if f.consistentRead == nil {
+		return nil, nil
+	}
+	return f.consistentRead(userID)
 }
 
 func (f *fakeRepo) GetUsersBySecondaryEmails(_ context.Context, emails []string) ([]*v1Models.User, error) {

--- a/cla-backend-go/v2/my_clas/signing_identity.go
+++ b/cla-backend-go/v2/my_clas/signing_identity.go
@@ -1,0 +1,426 @@
+// Copyright The Linux Foundation and each contributor to CommunityBridge.
+// SPDX-License-Identifier: MIT
+
+package my_clas
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/go-openapi/strfmt"
+	v1Models "github.com/linuxfoundation/easycla/cla-backend-go/gen/v1/models"
+	"github.com/linuxfoundation/easycla/cla-backend-go/gen/v2/models"
+	log "github.com/linuxfoundation/easycla/cla-backend-go/logging"
+	"github.com/linuxfoundation/easycla/cla-backend-go/user"
+	"github.com/linuxfoundation/easycla/cla-backend-go/utils"
+	"github.com/sirupsen/logrus"
+)
+
+// Refusal reason codes. Each refusal carries its own code so that refusals can be counted
+// by reason rather than in aggregate: a contested account and an unclaimed record both
+// look like "binding failed", but they need different responses from different people, and
+// a single counter cannot tell an operator which one is happening.
+const (
+	// ReasonIdentityUnavailable is returned when the request carries no LF identity to
+	// associate the account with. Nothing is inferred from its absence.
+	ReasonIdentityUnavailable = "identity_unavailable"
+	// ReasonRecordConflict is returned when the account is held by a record belonging to
+	// a different LF identity. The record is left untouched.
+	ReasonRecordConflict = "record_conflict"
+	// ReasonRecordUnclaimed is returned when the account is held by a record that names
+	// nobody. Claiming it would need proof the caller owns the account, which this
+	// service no longer has - see resolveExistingGithubRecord.
+	ReasonRecordUnclaimed = "record_unclaimed"
+	// ReasonDuplicateGithubID is returned when more than one record holds the account.
+	// The index does not enforce uniqueness, so this is detected rather than assumed.
+	ReasonDuplicateGithubID = "duplicate_github_id"
+	// ReasonLFRecordAlreadyBound is returned when the caller's own record already holds a
+	// different account. A record holds one account, so this is a refusal, not a swap.
+	ReasonLFRecordAlreadyBound = "lf_record_already_bound"
+	// ReasonRecordedMismatch is returned when what ended up on the record is not what was
+	// submitted, which is the one check the caller cannot make for itself.
+	ReasonRecordedMismatch = "recorded_mismatch"
+	// ReasonIdentityMismatch is returned when the two identities on the request disagree -
+	// the one the gateway authenticated and the one the token carries. It should never
+	// fire; it is here because the write uses the token's identity, so a disagreement
+	// would record the submitted GitHub account against a different person.
+	ReasonIdentityMismatch = "identity_mismatch"
+)
+
+// Resolution outcomes, reported for observability. They are not behavioural for the caller.
+const (
+	outcomeMatched = "matched"
+	outcomeCreated = "created"
+	outcomeAdopted = "adopted"
+)
+
+// selectedAccount is the GitHub account the caller submitted. It is named for what it is -
+// a selection made upstream - rather than for anything this service has established about
+// it. Nothing here verifies that the caller owns it; that judgement is made by LFX Self
+// Serve from the accounts Auth0 reports as linked, and this service records its word.
+type selectedAccount struct {
+	ID       int64
+	Username string
+}
+
+// Refusal is a decision not to record an association, carrying the reason that decision
+// was reached. Every refusal reachable before the write writes nothing: there is no
+// partial-success path on those, because a refusal after a write would leave behind an
+// association the evidence does not support.
+//
+// ReasonRecordedMismatch is the exception, and the only one. It is also raised after the
+// write, when the record cannot be read back holding what was submitted, and it does not
+// compensate that write - a second unconfirmed write on a record this service has just
+// lost confidence about is not an improvement. Retrying is safe: a record already holding
+// the submitted account resolves as outcomeMatched.
+type Refusal struct {
+	Reason  string
+	Message string
+}
+
+func (r *Refusal) Error() string {
+	return fmt.Sprintf("%s: %s", r.Reason, r.Message)
+}
+
+func refuse(reason, message string) *Refusal {
+	return &Refusal{Reason: reason, Message: message}
+}
+
+// UsersWriter is the subset of the users service used to record a confirmed association.
+// It is the users service rather than its repository so that the create and update both
+// emit their existing user.created / user.updated events, which is what makes the
+// association durably observable without a new mechanism.
+type UsersWriter interface {
+	CreateUser(user *v1Models.User, claUser *user.CLAUser) (*v1Models.User, error)
+	UpdateUser(userID string, updates map[string]interface{}) (*v1Models.User, error)
+	GetUser(userID string) (*v1Models.User, error)
+}
+
+// BindSigningIdentity records the GitHub account the caller submitted against the
+// contributor's EasyCLA user record, and returns that record's identifier for the CLA
+// hand-off to consume.
+//
+// The submitted account is taken on trust. Ownership is established upstream by LFX Self
+// Serve, which offers only the accounts Auth0 reports the contributor has linked, and the
+// caller is authenticated as that service. This endpoint therefore checks that recording
+// the account is safe for records that already exist - it cannot check that the account is
+// the caller's, and does not pretend to.
+func (s *service) BindSigningIdentity(ctx context.Context, githubID int64, githubUsername string) (*models.SigningIdentity, error) {
+	f := logrus.Fields{
+		"functionName":   "v2.my_clas.signing_identity.BindSigningIdentity",
+		utils.XREQUESTID: ctx.Value(utils.XREQUESTID),
+		"githubID":       githubID,
+		"githubUsername": githubUsername,
+	}
+
+	caller := user.VerifiedCallerFromContext(ctx)
+	if caller == nil || caller.LFUsername == "" {
+		// Without an LF identity there is nothing to associate the account with, and the
+		// GitHub-first lookup below would fall through to a create that could not be
+		// found again.
+		return nil, s.refusal(f, ReasonIdentityUnavailable, "the request carries no LF identity to associate the GitHub account with")
+	}
+	f["lfUsername"] = caller.LFUsername
+
+	selected := selectedAccount{ID: githubID, Username: githubUsername}
+
+	record, outcome, err := s.resolveSigningRecord(ctx, f, caller, selected)
+	if err != nil {
+		return nil, err
+	}
+	if record == nil {
+		// The write paths re-read the record they just wrote and report a miss as no
+		// record and no error, so a resolution can succeed and still hand back nothing.
+		// Dereferencing that below would panic on a request that had already written.
+		return nil, s.refusal(f, ReasonRecordedMismatch, "the resolved user record could not be read back to confirm what was recorded")
+	}
+
+	// What was recorded must equal what was submitted. This is the one check the caller
+	// cannot perform for itself, because only this side sees what the store accepted.
+	//
+	// Read consistently, on the base table. The lookup that resolved this record went
+	// through a global secondary index, which is always eventually consistent, so the
+	// record it returned may no longer hold the account it was indexed under - which is
+	// exactly what this check is here to catch. An eventually consistent confirmation
+	// could not tell that apart from its own stale view, and would refuse a contributor
+	// whose write had in fact succeeded.
+	confirmed, err := s.repo.GetUserByIDConsistent(ctx, record.UserID)
+	if err != nil {
+		log.WithFields(f).WithError(err).Warn("unable to re-read the resolved user record to confirm what was recorded")
+		return nil, err
+	}
+	if confirmed == nil || confirmed.GithubID != formatGithubID(selected.ID) {
+		f["recordedGithubID"] = recordedGithubID(confirmed)
+		return nil, s.refusal(f, ReasonRecordedMismatch, "the GitHub account recorded on the user record is not the account that was submitted")
+	}
+
+	// An empty identifier passes every check above and still breaks the hand-off: the
+	// Console renders "invalid user ID in the URL", which reads as a broken product rather
+	// than a failed resolution. Refuse here, where the reason is still known.
+	if confirmed.UserID == "" {
+		return nil, s.refusal(f, ReasonRecordedMismatch, "the resolved user record carries no identifier for the hand-off to use")
+	}
+
+	f["outcome"] = outcome
+	f["userID"] = confirmed.UserID
+	log.WithFields(f).Debug("recorded the signing GitHub identity")
+
+	userID := confirmed.UserID
+	accountID := selected.ID
+	return &models.SigningIdentity{
+		UserID:         &userID,
+		GithubID:       &accountID,
+		GithubUsername: confirmed.GithubUsername,
+		Outcome:        outcome,
+	}, nil
+}
+
+// resolveSigningRecord finds or creates the user record the submitted account belongs to.
+//
+// The lookup by account number comes before any lookup by LF identity, and the order is
+// load-bearing rather than stylistic. The authentication middleware creates an LF-only
+// record whenever its own lookups miss, unconditionally, and it runs before this handler
+// on the same request - so an LF-first resolution would find that freshly created empty
+// record and bind the account to it while a record keyed on that account already existed,
+// producing exactly the two-records-one-account state this feature exists to prevent.
+//
+// Every outcome that is not clearly safe is a refusal. That is deliberate: a wrong guess
+// here silently detaches a working association, and the contributor finds out through a
+// pull-request check that stopped passing rather than through anything this service says.
+// It matters more here than it would with provider-issued evidence, because the account
+// number arriving on the request is the caller's word - so these checks, which reason only
+// about what the store already holds, are the whole of what stands between a mistaken or
+// forged selection and someone else's record.
+func (s *service) resolveSigningRecord(ctx context.Context, f logrus.Fields, caller *user.CLAUser, selected selectedAccount) (*v1Models.User, string, error) {
+	byGithub, err := s.repo.GetUsersByGithubID(ctx, selected.ID)
+	if err != nil {
+		log.WithFields(f).WithError(err).Warn("unable to look up user records by GitHub account number")
+		return nil, "", err
+	}
+
+	if len(byGithub) > 1 {
+		// The index does not enforce uniqueness and the repository's own single-result
+		// lookup only warns before returning the first match, so this has to be detected
+		// deliberately. Resolving to whichever row happens to sort first would attach the
+		// signature to an arbitrary one of two contested records.
+		f["matchingRecords"] = len(byGithub)
+		return nil, "", s.refusal(f, ReasonDuplicateGithubID, "more than one contributor record holds this GitHub account - the conflict needs resolving before it can be signed with")
+	}
+
+	if len(byGithub) == 1 {
+		return s.resolveExistingGithubRecord(ctx, f, caller, selected, byGithub[0])
+	}
+
+	byLF, err := s.repo.GetUsersByLFUsername(ctx, caller.LFUsername)
+	if err != nil {
+		log.WithFields(f).WithError(err).Warn("unable to look up user records by LF identity")
+		return nil, "", err
+	}
+
+	if len(byLF) == 0 {
+		return s.createSigningRecord(f, caller, selected)
+	}
+
+	if len(byLF) > 1 {
+		// Several records share this LF identity, so there is no single record to record
+		// the account on and no basis for choosing between them. Picking one would bind
+		// the account to a record the contributor may not be signing from.
+		f["matchingRecords"] = len(byLF)
+		return nil, "", s.refusal(f, ReasonRecordConflict, "more than one contributor record carries this LF identity - the conflict needs resolving before an account can be recorded")
+	}
+
+	return s.adoptSigningRecord(ctx, f, selected, byLF[0])
+}
+
+// resolveExistingGithubRecord handles the record already keyed on the submitted account.
+func (s *service) resolveExistingGithubRecord(ctx context.Context, f logrus.Fields, caller *user.CLAUser, selected selectedAccount, record *v1Models.User) (*v1Models.User, string, error) {
+	f["recordUserID"] = record.UserID
+
+	if record.LfUsername == "" {
+		// A record created by a GitHub-only flow: it holds the account but names nobody,
+		// so the CLA never appears in anyone's list. Writing the caller's LF identity onto
+		// it would reunite the contributor with their own signature history - and, if the
+		// account was not theirs, would hand them somebody else's instead, because the
+		// record carries signatures already.
+		//
+		// Doing that needs proof the caller owns the account. This service has none: the
+		// account number is the caller's own submission. So the record is left untouched
+		// and the reason is reported, rather than guessing on the odds that whoever asked
+		// is the rightful owner.
+		return nil, "", s.refusal(f, ReasonRecordUnclaimed, "this GitHub account is on a contributor record that names nobody, and claiming it needs proof of ownership this request cannot provide")
+	}
+
+	// Compared without regard to case, as the handler compares the two identities on the
+	// request. A record written with different casing to the token's claim is the same
+	// person, and refusing them here would lock them out of their own record.
+	if !strings.EqualFold(record.LfUsername, caller.LFUsername) {
+		// Reassigning an account two LF identities both claim would leave the losing
+		// contributor's CLA no longer covering their commits, with nothing on screen to
+		// point at. Reconciling a contested account is out of scope, and the
+		// account-number index does not enforce uniqueness, so this is detected here
+		// rather than prevented by the store.
+		f["recordLfUsername"] = record.LfUsername
+		return nil, "", s.refusal(f, ReasonRecordConflict, "this GitHub account is already associated with a different contributor record")
+	}
+
+	// The handle is display-only and drifts whenever the contributor renames themselves
+	// on GitHub. Refreshing it is not a re-association - the account number, which is what
+	// anything matches on, is unchanged and is not rewritten here.
+	if selected.Username != "" && record.GithubUsername != selected.Username {
+		// Everything decided above came from the account-number index, which is allowed
+		// to serve an image the base table has already moved past. If this record has
+		// since been rebound to another account, writing the submitted handle onto it
+		// would leave the record naming one account and numbered as another - and the
+		// handle is what approval lists match on, so the damage outlives the request.
+		// Confirm against the base table before writing, not after.
+		if err := s.confirmStillHolds(ctx, f, record.UserID, selected); err != nil {
+			return nil, "", err
+		}
+
+		updated, err := s.usersWriter.UpdateUser(record.UserID, map[string]interface{}{
+			"user_github_username": selected.Username,
+		})
+		if err != nil {
+			log.WithFields(f).WithError(err).Warn("unable to refresh the stored GitHub handle")
+			return nil, "", err
+		}
+		if updated == nil {
+			// The update path re-reads the record it wrote without consistency, and
+			// reports a miss as no record and no error. Only the identifier is needed
+			// from it and that is unchanged, so carry the record already in hand and let
+			// the consistent confirmation decide - refusing here would fail a
+			// contributor whose write succeeded.
+			return record, outcomeMatched, nil
+		}
+		return updated, outcomeMatched, nil
+	}
+
+	return record, outcomeMatched, nil
+}
+
+// createSigningRecord creates a contributor record carrying both the LF identity and the
+// submitted account, for a contributor who has neither.
+func (s *service) createSigningRecord(f logrus.Fields, caller *user.CLAUser, selected selectedAccount) (*v1Models.User, string, error) {
+	// GithubID is a string on this model and the repository writes it as a DynamoDB
+	// number, so a decimal string is the correct value at this seam. It is not a widening
+	// of the account's type - see adoptSigningRecord for the seam where it matters.
+	newUser := &v1Models.User{
+		LfUsername:     caller.LFUsername,
+		LfEmail:        strfmt.Email(caller.LFEmail),
+		Username:       caller.Name,
+		GithubID:       formatGithubID(selected.ID),
+		GithubUsername: selected.Username,
+	}
+
+	created, err := s.usersWriter.CreateUser(newUser, caller)
+	if err != nil {
+		log.WithFields(f).WithError(err).Warn("unable to create the contributor record")
+		return nil, "", err
+	}
+
+	return created, outcomeCreated, nil
+}
+
+// adoptSigningRecord records the submitted account on the caller's existing record, or
+// refuses when that record already holds a different one.
+func (s *service) adoptSigningRecord(ctx context.Context, f logrus.Fields, selected selectedAccount, record *v1Models.User) (*v1Models.User, string, error) {
+	f["recordUserID"] = record.UserID
+
+	// The record arrived from the LF-identity index, whose view of user_github_id can lag
+	// the base table. Deciding "this record holds no account yet" from that view and then
+	// writing unconditionally is how a binding made moments ago gets overwritten - and the
+	// confirmation at the end of the request would see the account it submitted and call
+	// it a success, so the refusal this branch exists for would never fire. Re-read the
+	// record consistently and decide on that.
+	if fresh, err := s.repo.GetUserByIDConsistent(ctx, record.UserID); err != nil {
+		log.WithFields(f).WithError(err).Warn("unable to re-read the contributor record before recording the account")
+		return nil, "", err
+	} else if fresh != nil {
+		record = fresh
+	}
+
+	if record.GithubID != "" && record.GithubID != formatGithubID(selected.ID) {
+		// Overwriting here is the mistake this branch exists to prevent. A contributor
+		// record holds one GitHub account, and replacing it detaches the previous one:
+		// commits authored by it stop matching any record, and a CLA that worked
+		// yesterday fails today with nothing on screen to point at.
+		f["recordGithubID"] = record.GithubID
+		return nil, "", s.refusal(f, ReasonLFRecordAlreadyBound, "this contributor record already has a different GitHub account recorded against it")
+	}
+
+	if record.GithubID == formatGithubID(selected.ID) {
+		// The account-number index missed a record that in fact holds the account, which
+		// a global secondary index is allowed to do briefly after a write. Nothing needs
+		// recording.
+		return record, outcomeMatched, nil
+	}
+
+	// The account number MUST be written as a Go integer. The update path marshals
+	// whatever it is given, so a decimal string here would be stored as a DynamoDB string
+	// attribute, which the numeric key condition on the account-number index would then
+	// never match again - the association would look correct in the record and be
+	// invisible to every lookup.
+	updates := map[string]interface{}{"user_github_id": selected.ID}
+
+	// A blank handle is absent, not a value to record. The handle keys its own index, so
+	// an empty string is rejected outright as an index key - the whole write fails, and
+	// the account never reaches the record. Were it accepted, it would replace whatever
+	// handle the record already held with nothing.
+	if selected.Username != "" {
+		updates["user_github_username"] = selected.Username
+	}
+
+	updated, err := s.usersWriter.UpdateUser(record.UserID, updates)
+	if err != nil {
+		log.WithFields(f).WithError(err).Warn("unable to record the GitHub account on the contributor record")
+		return nil, "", err
+	}
+	if updated == nil {
+		// As in resolveExistingGithubRecord: a missed read-back after a write that
+		// succeeded is not grounds to refuse. The identifier is unchanged, and the
+		// consistent confirmation is what decides.
+		return record, outcomeAdopted, nil
+	}
+
+	return updated, outcomeAdopted, nil
+}
+
+// confirmStillHolds re-reads a record on the base table and refuses unless it still holds
+// the submitted account. It guards a write that an index-sourced decision is about to make
+// on a record that index may be describing stale, so the read must be consistent to be
+// worth performing at all.
+func (s *service) confirmStillHolds(ctx context.Context, f logrus.Fields, userID string, selected selectedAccount) error {
+	fresh, err := s.repo.GetUserByIDConsistent(ctx, userID)
+	if err != nil {
+		log.WithFields(f).WithError(err).Warn("unable to re-read the contributor record before writing to it")
+		return err
+	}
+	if fresh == nil || fresh.GithubID != formatGithubID(selected.ID) {
+		f["recordedGithubID"] = recordedGithubID(fresh)
+		return s.refusal(f, ReasonRecordedMismatch, "the GitHub account recorded on the user record is not the account that was submitted")
+	}
+	return nil
+}
+
+// refusal logs a refusal under its own reason code and returns it. Logging here rather
+// than at each call site is what keeps every refusal countable by reason.
+func (s *service) refusal(f logrus.Fields, reason, message string) *Refusal {
+	log.WithFields(f).WithField("refusalReason", reason).Warn(message)
+	return refuse(reason, message)
+}
+
+// formatGithubID renders an account number the way the users repository and the v1 user
+// model represent it - a decimal string that the repository converts to a DynamoDB number
+// at the attribute boundary.
+func formatGithubID(githubID int64) string {
+	return strconv.FormatInt(githubID, 10)
+}
+
+func recordedGithubID(record *v1Models.User) string {
+	if record == nil {
+		return ""
+	}
+	return record.GithubID
+}

--- a/cla-backend-go/v2/my_clas/signing_identity_test.go
+++ b/cla-backend-go/v2/my_clas/signing_identity_test.go
@@ -1,0 +1,570 @@
+// Copyright The Linux Foundation and each contributor to CommunityBridge.
+// SPDX-License-Identifier: MIT
+
+package my_clas
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	v1Models "github.com/linuxfoundation/easycla/cla-backend-go/gen/v1/models"
+	"github.com/linuxfoundation/easycla/cla-backend-go/gen/v2/models"
+	"github.com/linuxfoundation/easycla/cla-backend-go/user"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	callerLFUsername     = "contributor"
+	chosenGithubID       = int64(87654321)
+	chosenGithubUsername = "octocat-work"
+	otherGithubID        = int64(12345678)
+)
+
+// bind submits the chosen account the way the calling service does - as a plain value this
+// side does not verify. Every test goes through it so that no test can accidentally assert
+// on an ownership check this service no longer performs.
+func bind(svc *service, ctx context.Context) (*models.SigningIdentity, error) {
+	return svc.BindSigningIdentity(ctx, chosenGithubID, chosenGithubUsername)
+}
+
+// fakeUsersWriter records what was written so tests can assert on the record rather than
+// only on the returned error. Several of this feature's requirements are about a record
+// being left alone, and an assertion on the error alone passes for an implementation that
+// returns an error after having already written.
+type fakeUsersWriter struct {
+	byID      map[string]*v1Models.User
+	created   []*v1Models.User
+	updates   map[string]map[string]interface{}
+	createErr error
+	updateErr error
+	getErr    error
+	// updateReadBackMisses reproduces the users service's own convention: it applies the
+	// update, then re-reads the record without consistency and returns no record and no
+	// error when that read misses.
+	updateReadBackMisses bool
+}
+
+func newFakeUsersWriter(records ...*v1Models.User) *fakeUsersWriter {
+	byID := map[string]*v1Models.User{}
+	for _, record := range records {
+		byID[record.UserID] = record
+	}
+	return &fakeUsersWriter{byID: byID, updates: map[string]map[string]interface{}{}}
+}
+
+func (f *fakeUsersWriter) CreateUser(newUser *v1Models.User, _ *user.CLAUser) (*v1Models.User, error) {
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+	created := *newUser
+	created.UserID = "created-user-id"
+	f.created = append(f.created, &created)
+	f.byID[created.UserID] = &created
+	return &created, nil
+}
+
+func (f *fakeUsersWriter) UpdateUser(userID string, updates map[string]interface{}) (*v1Models.User, error) {
+	if f.updateErr != nil {
+		return nil, f.updateErr
+	}
+	f.updates[userID] = updates
+
+	record, ok := f.byID[userID]
+	if !ok {
+		return nil, errors.New("no such user record")
+	}
+	updated := *record
+	if githubID, isInt64 := updates["user_github_id"].(int64); isInt64 {
+		updated.GithubID = formatGithubID(githubID)
+	}
+	if handle, ok := updates["user_github_username"].(string); ok {
+		updated.GithubUsername = handle
+	}
+	if lfUsername, ok := updates["lf_username"].(string); ok {
+		updated.LfUsername = lfUsername
+	}
+	f.byID[userID] = &updated
+	if f.updateReadBackMisses {
+		return nil, nil
+	}
+	return &updated, nil
+}
+
+func (f *fakeUsersWriter) GetUser(userID string) (*v1Models.User, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	return f.byID[userID], nil
+}
+
+// newBindingService wires the post-write confirmation to the writer's own store, so a test
+// asserting on the record and the confirmation the service performs are reading the same
+// thing. Production gets the same property from a strongly consistent base-table read.
+func newBindingService(repo Repository, writer UsersWriter) *service {
+	if fake, isFake := repo.(*fakeRepo); isFake && fake.consistentRead == nil {
+		if store, hasStore := writer.(*fakeUsersWriter); hasStore {
+			fake.consistentRead = func(userID string) (*v1Models.User, error) {
+				return store.GetUser(userID)
+			}
+		}
+	}
+	return &service{repo: repo, usersWriter: writer}
+}
+
+// callerContext builds the request context the authentication middleware would produce for
+// an authenticated contributor. It carries an LF identity and nothing about GitHub: which
+// account the contributor owns is not something this service is told or checks.
+func callerContext() context.Context {
+	return user.ContextWithVerifiedCaller(context.Background(), &user.CLAUser{
+		LFUsername: callerLFUsername,
+		LFEmail:    "contributor@example.org",
+		Name:       "A Contributor",
+	})
+}
+
+func assertRefused(t *testing.T, err error, reason string) {
+	t.Helper()
+	var refusal *Refusal
+	require.True(t, errors.As(err, &refusal), "expected a refusal, got %v", err)
+	assert.Equal(t, reason, refusal.Reason)
+}
+
+// --- Refusals (T015) ---------------------------------------------------------------
+
+func TestBindSigningIdentity_NoLFIdentityRefusesAndWritesNothing(t *testing.T) {
+	writer := newFakeUsersWriter()
+	svc := newBindingService(&fakeRepo{}, writer)
+
+	// No verified caller on the context at all - the middleware never ran or the token
+	// was unverifiable. The LF identity is the only verified thing this write rests on,
+	// so its absence has to stop the write rather than fall through to a create.
+	_, err := bind(svc, context.Background())
+
+	assertRefused(t, err, ReasonIdentityUnavailable)
+	assert.Empty(t, writer.created, "a refusal must write nothing")
+	assert.Empty(t, writer.updates, "a refusal must write nothing")
+}
+
+// Documents the trust boundary as a test rather than only as a comment, so that anyone
+// re-adding an ownership check here has to delete an assertion that says not to. The
+// account submitted is recorded whether or not this service could show it is the caller's,
+// because establishing that is the calling service's job.
+func TestBindSigningIdentity_SubmittedAccountIsNotCheckedForOwnership(t *testing.T) {
+	writer := newFakeUsersWriter()
+	svc := newBindingService(&fakeRepo{}, writer)
+
+	result, err := bind(svc, callerContext())
+
+	require.NoError(t, err)
+	assert.Equal(t, chosenGithubID, *result.GithubID)
+	require.Len(t, writer.created, 1)
+	assert.Equal(t, formatGithubID(chosenGithubID), writer.created[0].GithubID)
+}
+
+func TestBindSigningIdentity_RecordedMismatchRefuses(t *testing.T) {
+	// The record the resolution settles on carries a different account than the one
+	// submitted. This is the one check the caller cannot make for itself, because only
+	// this side sees what the store accepted.
+	record := &v1Models.User{UserID: "user-1", LfUsername: callerLFUsername, GithubID: formatGithubID(chosenGithubID)}
+	repo := &fakeRepo{byGithubID: map[int64][]*v1Models.User{chosenGithubID: {record}}}
+
+	writer := newFakeUsersWriter(&v1Models.User{
+		UserID:     "user-1",
+		LfUsername: callerLFUsername,
+		GithubID:   formatGithubID(otherGithubID),
+	})
+	svc := newBindingService(repo, writer)
+
+	_, err := bind(svc, callerContext())
+
+	assertRefused(t, err, ReasonRecordedMismatch)
+}
+
+// --- Resolution paths (T016) -------------------------------------------------------
+
+func TestBindSigningIdentity_ExistingRecordIsReusedNotDuplicated(t *testing.T) {
+	record := &v1Models.User{
+		UserID:         "user-1",
+		LfUsername:     callerLFUsername,
+		GithubID:       formatGithubID(chosenGithubID),
+		GithubUsername: "octocat-work",
+	}
+	repo := &fakeRepo{byGithubID: map[int64][]*v1Models.User{chosenGithubID: {record}}}
+	writer := newFakeUsersWriter(record)
+	svc := newBindingService(repo, writer)
+
+	result, err := bind(svc, callerContext())
+
+	require.NoError(t, err)
+	assert.Equal(t, "user-1", *result.UserID)
+	assert.Equal(t, chosenGithubID, *result.GithubID)
+	assert.Equal(t, outcomeMatched, result.Outcome)
+	assert.Empty(t, writer.created, "an existing record must not be duplicated")
+	assert.Empty(t, writer.updates, "a matched record needs no write")
+}
+
+func TestBindSigningIdentity_FirstTimeSignerGetsARecordCarryingBoth(t *testing.T) {
+	writer := newFakeUsersWriter()
+	svc := newBindingService(&fakeRepo{}, writer)
+
+	result, err := bind(svc, callerContext())
+
+	require.NoError(t, err)
+	assert.Equal(t, outcomeCreated, result.Outcome)
+	require.Len(t, writer.created, 1)
+	assert.Equal(t, callerLFUsername, writer.created[0].LfUsername)
+	assert.Equal(t, formatGithubID(chosenGithubID), writer.created[0].GithubID)
+	assert.Equal(t, "octocat-work", writer.created[0].GithubUsername)
+}
+
+func TestBindSigningIdentity_ContestedRecordRefusesAndIsLeftUntouched(t *testing.T) {
+	contested := &v1Models.User{
+		UserID:     "user-someone-else",
+		LfUsername: "someone-else",
+		GithubID:   formatGithubID(chosenGithubID),
+	}
+	repo := &fakeRepo{byGithubID: map[int64][]*v1Models.User{chosenGithubID: {contested}}}
+	writer := newFakeUsersWriter(contested)
+	svc := newBindingService(repo, writer)
+
+	_, err := bind(svc, callerContext())
+
+	assertRefused(t, err, ReasonRecordConflict)
+	// Asserted on the record, not merely on the error: an implementation that reassigns
+	// and then errors would pass an error-only assertion.
+	assert.Equal(t, "someone-else", writer.byID["user-someone-else"].LfUsername)
+	assert.Empty(t, writer.updates)
+}
+
+func TestBindSigningIdentity_OwnRecordInDifferentCaseIsNotContested(t *testing.T) {
+	// Same contributor, recorded with different casing to the one their token claims. The
+	// handler already treats the two identities on a request as equal regardless of case, so
+	// treating them as different people here would refuse someone their own record.
+	own := &v1Models.User{
+		UserID:     resolvedUserID,
+		LfUsername: strings.ToUpper(callerLFUsername),
+		GithubID:   formatGithubID(chosenGithubID),
+	}
+	repo := &fakeRepo{byGithubID: map[int64][]*v1Models.User{chosenGithubID: {own}}}
+	writer := newFakeUsersWriter(own)
+	svc := newBindingService(repo, writer)
+
+	identity, err := bind(svc, callerContext())
+
+	require.NoError(t, err)
+	assert.Equal(t, resolvedUserID, *identity.UserID)
+	assert.Equal(t, outcomeMatched, identity.Outcome)
+}
+
+func TestBindSigningIdentity_SeveralRecordsHoldingTheAccountRefuse(t *testing.T) {
+	repo := &fakeRepo{byGithubID: map[int64][]*v1Models.User{
+		chosenGithubID: {
+			{UserID: "user-1", LfUsername: callerLFUsername, GithubID: formatGithubID(chosenGithubID)},
+			{UserID: "user-2", LfUsername: "someone-else", GithubID: formatGithubID(chosenGithubID)},
+		},
+	}}
+	writer := newFakeUsersWriter()
+	svc := newBindingService(repo, writer)
+
+	_, err := bind(svc, callerContext())
+
+	// The index does not enforce uniqueness, so resolving to whichever row sorts first
+	// would attach the signature to an arbitrary one of two contested records.
+	assertRefused(t, err, ReasonDuplicateGithubID)
+	assert.Empty(t, writer.updates)
+}
+
+// A record that resolves and holds the right account but carries no identifier passes every
+// other check and still dead-ends: the Console renders "invalid user ID in the URL", which the
+// contributor reads as a broken product rather than a failed lookup.
+func TestBindSigningIdentity_EmptyIdentifierIsNeverHandedOff(t *testing.T) {
+	anonymous := &v1Models.User{UserID: "", LfUsername: callerLFUsername, GithubID: formatGithubID(chosenGithubID)}
+	repo := &fakeRepo{byGithubID: map[int64][]*v1Models.User{chosenGithubID: {anonymous}}}
+	writer := newFakeUsersWriter(anonymous)
+	svc := newBindingService(repo, writer)
+
+	_, err := bind(svc, callerContext())
+
+	require.Error(t, err)
+	var refusal *Refusal
+	require.True(t, errors.As(err, &refusal))
+}
+
+// --- Unclaimed records -------------------------------------------------------------
+
+// A record created by a GitHub-only flow: it holds the account but names nobody, so the
+// CLA never appears in anyone's list. Writing the caller's LF identity onto it would
+// reunite the rightful contributor with their signature history - or hand it to whoever
+// asked first, since the account number arrives as the caller's own submission and nothing
+// here can tell those two cases apart.
+func TestBindSigningIdentity_UnclaimedRecordIsRefusedAndLeftUntouched(t *testing.T) {
+	detached := &v1Models.User{UserID: "user-detached", GithubID: formatGithubID(chosenGithubID)}
+	repo := &fakeRepo{byGithubID: map[int64][]*v1Models.User{chosenGithubID: {detached}}}
+	writer := newFakeUsersWriter(detached)
+	svc := newBindingService(repo, writer)
+
+	_, err := bind(svc, callerContext())
+
+	assertRefused(t, err, ReasonRecordUnclaimed)
+	// Asserted on the record, not only on the error: an implementation that claims the
+	// record and then errors would pass an error-only assertion, and the signatures on
+	// that record would already belong to somebody else.
+	assert.Empty(t, writer.updates)
+	assert.Equal(t, "", writer.byID["user-detached"].LfUsername)
+}
+
+// The refusal must not be worked around by falling through to the caller's own record:
+// that would leave the account on two rows, which is the state this resolution order
+// exists to prevent.
+func TestBindSigningIdentity_UnclaimedRecordDoesNotFallThroughToTheCallersRecord(t *testing.T) {
+	detached := &v1Models.User{UserID: "user-detached", GithubID: formatGithubID(chosenGithubID)}
+	repo := &fakeRepo{
+		byGithubID: map[int64][]*v1Models.User{chosenGithubID: {detached}},
+		// The middleware creates an LF-only record on every request whose lookups miss,
+		// so the caller plausibly has one by the time this runs.
+		byLFUsername: map[string][]*v1Models.User{callerLFUsername: {{UserID: "user-lf-only", LfUsername: callerLFUsername}}},
+	}
+	writer := newFakeUsersWriter(detached)
+	svc := newBindingService(repo, writer)
+
+	_, err := bind(svc, callerContext())
+
+	assertRefused(t, err, ReasonRecordUnclaimed)
+	assert.Empty(t, writer.created)
+	assert.NotContains(t, writer.updates, "user-lf-only")
+}
+
+// The case most likely to be missed, and the most damaging to get wrong: the obvious
+// "no GitHub record, so adopt the caller's record" shortcut walks straight into it.
+func TestBindSigningIdentity_CallersRecordHoldingAnotherAccountIsNeverOverwritten(t *testing.T) {
+	own := &v1Models.User{
+		UserID:         "user-own",
+		LfUsername:     callerLFUsername,
+		GithubID:       formatGithubID(otherGithubID),
+		GithubUsername: "octocat",
+	}
+	repo := &fakeRepo{byLFUsername: map[string][]*v1Models.User{callerLFUsername: {own}}}
+	writer := newFakeUsersWriter(own)
+	svc := newBindingService(repo, writer)
+
+	_, err := bind(svc, callerContext())
+
+	assertRefused(t, err, ReasonLFRecordAlreadyBound)
+	// Asserted on the record: an overwrite here is invisible from the UI and silently
+	// stops the first account's commits matching anything.
+	assert.Equal(t, formatGithubID(otherGithubID), writer.byID["user-own"].GithubID)
+	assert.Empty(t, writer.updates)
+}
+
+func TestBindSigningIdentity_CallersRecordWithNoAccountAdoptsIt(t *testing.T) {
+	own := &v1Models.User{UserID: "user-own", LfUsername: callerLFUsername}
+	repo := &fakeRepo{byLFUsername: map[string][]*v1Models.User{callerLFUsername: {own}}}
+	writer := newFakeUsersWriter(own)
+	svc := newBindingService(repo, writer)
+
+	result, err := bind(svc, callerContext())
+
+	require.NoError(t, err)
+	assert.Equal(t, outcomeAdopted, result.Outcome)
+	assert.Equal(t, "user-own", *result.UserID)
+	assert.Empty(t, writer.created, "the caller's existing record must be used, not duplicated")
+}
+
+// The account number must reach the update path as an integer. A decimal string would be
+// stored as a DynamoDB string attribute, which the numeric key condition on the
+// account-number index would never match again - the association would look right in the
+// record and be invisible to every lookup.
+func TestBindSigningIdentity_AdoptWritesTheAccountNumberAsAnInteger(t *testing.T) {
+	own := &v1Models.User{UserID: "user-own", LfUsername: callerLFUsername}
+	repo := &fakeRepo{byLFUsername: map[string][]*v1Models.User{callerLFUsername: {own}}}
+	writer := newFakeUsersWriter(own)
+	svc := newBindingService(repo, writer)
+
+	_, err := bind(svc, callerContext())
+
+	require.NoError(t, err)
+	require.Contains(t, writer.updates, "user-own")
+	assert.IsType(t, int64(0), writer.updates["user-own"]["user_github_id"])
+	assert.Equal(t, chosenGithubID, writer.updates["user-own"]["user_github_id"])
+}
+
+// A request may carry no handle at all - it is optional. The handle keys its own index, so
+// an empty string is rejected as an index key and takes the whole write down with it, which
+// would cost the contributor the account number too.
+func TestBindSigningIdentity_AdoptWithNoHandleWritesNoHandleAtAll(t *testing.T) {
+	own := &v1Models.User{UserID: "user-own", LfUsername: callerLFUsername}
+	repo := &fakeRepo{byLFUsername: map[string][]*v1Models.User{callerLFUsername: {own}}}
+	writer := newFakeUsersWriter(own)
+	svc := newBindingService(repo, writer)
+
+	// Submitted directly rather than through bind: the blank handle is the subject.
+	result, err := svc.BindSigningIdentity(callerContext(), chosenGithubID, "")
+
+	require.NoError(t, err)
+	assert.Equal(t, outcomeAdopted, result.Outcome)
+	require.Contains(t, writer.updates, "user-own")
+	assert.Equal(t, chosenGithubID, writer.updates["user-own"]["user_github_id"])
+	assert.NotContains(t, writer.updates["user-own"], "user_github_username",
+		"a blank handle is absent, not a value to record")
+}
+
+// The write succeeded; only the writer's own eventually consistent read-back of it missed. Refusing
+// here would fail a contributor whose account was in fact recorded, and dereferencing the
+// record it did not return would panic.
+func TestBindSigningIdentity_MissedReadBackAfterASuccessfulWriteStillSucceeds(t *testing.T) {
+	own := &v1Models.User{UserID: "user-own", LfUsername: callerLFUsername}
+	repo := &fakeRepo{byLFUsername: map[string][]*v1Models.User{callerLFUsername: {own}}}
+	writer := newFakeUsersWriter(own)
+	writer.updateReadBackMisses = true
+	svc := newBindingService(repo, writer)
+
+	result, err := bind(svc, callerContext())
+
+	require.NoError(t, err)
+	assert.Equal(t, "user-own", *result.UserID)
+	assert.Equal(t, chosenGithubID, *result.GithubID)
+}
+
+// Resolution must key on the account number before the LF identity. The authentication
+// middleware creates an LF-only record whenever its lookups miss, on this very request,
+// so an LF-first order would bind the account to that fresh empty record while a
+// record keyed on the account already existed.
+func TestBindSigningIdentity_ResolutionIsGithubFirst(t *testing.T) {
+	keyedOnAccount := &v1Models.User{
+		UserID:     "user-github-keyed",
+		LfUsername: callerLFUsername,
+		GithubID:   formatGithubID(chosenGithubID),
+	}
+	freshEmptyRecord := &v1Models.User{UserID: "user-lf-only", LfUsername: callerLFUsername}
+
+	repo := &fakeRepo{
+		byGithubID:   map[int64][]*v1Models.User{chosenGithubID: {keyedOnAccount}},
+		byLFUsername: map[string][]*v1Models.User{callerLFUsername: {freshEmptyRecord}},
+	}
+	writer := newFakeUsersWriter(keyedOnAccount, freshEmptyRecord)
+	svc := newBindingService(repo, writer)
+
+	result, err := bind(svc, callerContext())
+
+	require.NoError(t, err)
+	assert.Equal(t, "user-github-keyed", *result.UserID)
+	assert.NotContains(t, writer.updates, "user-lf-only", "the empty LF-only record must not be bound")
+}
+
+func TestBindSigningIdentity_SeveralRecordsSharingTheLFIdentityRefuse(t *testing.T) {
+	repo := &fakeRepo{byLFUsername: map[string][]*v1Models.User{
+		callerLFUsername: {
+			{UserID: "user-1", LfUsername: callerLFUsername},
+			{UserID: "user-2", LfUsername: callerLFUsername},
+		},
+	}}
+	writer := newFakeUsersWriter()
+	svc := newBindingService(repo, writer)
+
+	_, err := bind(svc, callerContext())
+
+	assertRefused(t, err, ReasonRecordConflict)
+	assert.Empty(t, writer.updates)
+	assert.Empty(t, writer.created)
+}
+
+func TestBindSigningIdentity_RenamedHandleIsRefreshedOnTheAccountNumber(t *testing.T) {
+	record := &v1Models.User{
+		UserID:         "user-1",
+		LfUsername:     callerLFUsername,
+		GithubID:       formatGithubID(chosenGithubID),
+		GithubUsername: "old-handle",
+	}
+	repo := &fakeRepo{byGithubID: map[int64][]*v1Models.User{chosenGithubID: {record}}}
+	writer := newFakeUsersWriter(record)
+	svc := newBindingService(repo, writer)
+
+	result, err := bind(svc, callerContext())
+
+	require.NoError(t, err)
+	// Matching is on the number, so a rename does not break resolution; the stored handle
+	// is display data and is brought up to date without re-associating anything.
+	assert.Equal(t, "octocat-work", result.GithubUsername)
+	assert.NotContains(t, writer.updates["user-1"], "user_github_id")
+}
+
+// --- Stale index images ------------------------------------------------------------
+//
+// Both indexes this service resolves through are global secondary indexes, so both are
+// allowed to serve an image the base table has already moved past. The two tests below
+// hold the index and the base table deliberately out of step, which is the state neither
+// a single-record fixture nor a happy-path test can reach.
+
+// The account-number index still lists the record under the submitted account; the base
+// table shows the record has since been rebound to another one. Refreshing the handle on
+// that evidence would leave the record naming one account and numbered as another - and
+// the handle is what CCLA approval lists are matched against, so the wrong one is not a
+// display defect.
+func TestBindSigningIdentity_StaleGithubIndexDoesNotOverwriteTheHandle(t *testing.T) {
+	stale := &v1Models.User{
+		UserID:         "user-1",
+		LfUsername:     callerLFUsername,
+		GithubID:       formatGithubID(chosenGithubID),
+		GithubUsername: "old-handle",
+	}
+	current := &v1Models.User{
+		UserID:         "user-1",
+		LfUsername:     callerLFUsername,
+		GithubID:       formatGithubID(otherGithubID),
+		GithubUsername: "current-handle",
+	}
+	repo := &fakeRepo{
+		byGithubID:     map[int64][]*v1Models.User{chosenGithubID: {stale}},
+		consistentRead: func(string) (*v1Models.User, error) { return current, nil },
+	}
+	writer := newFakeUsersWriter(current)
+	svc := newBindingService(repo, writer)
+
+	_, err := bind(svc, callerContext())
+
+	assertRefused(t, err, ReasonRecordedMismatch)
+	assert.Empty(t, writer.updates, "a record the base table says holds another account must not be written to")
+	assert.Equal(t, "current-handle", current.GithubUsername)
+}
+
+// The LF-identity index shows the caller's record holding no account, so the adopt branch
+// looks safe; the base table shows an account recorded on it already. Writing on the index
+// image would overwrite that binding, and the post-write confirmation would then find the
+// account it submitted and call it a success - so lf_record_already_bound would never fire
+// for the one case it exists to catch.
+func TestBindSigningIdentity_StaleLFIndexDoesNotOverwriteANewerBinding(t *testing.T) {
+	stale := &v1Models.User{UserID: "user-own", LfUsername: callerLFUsername}
+	current := &v1Models.User{
+		UserID:     "user-own",
+		LfUsername: callerLFUsername,
+		GithubID:   formatGithubID(otherGithubID),
+	}
+	repo := &fakeRepo{
+		byLFUsername:   map[string][]*v1Models.User{callerLFUsername: {stale}},
+		consistentRead: func(string) (*v1Models.User, error) { return current, nil },
+	}
+	writer := newFakeUsersWriter(current)
+	svc := newBindingService(repo, writer)
+
+	_, err := bind(svc, callerContext())
+
+	assertRefused(t, err, ReasonLFRecordAlreadyBound)
+	assert.Empty(t, writer.updates, "the newer binding must survive a stale index read")
+	assert.Equal(t, formatGithubID(otherGithubID), current.GithubID)
+}
+
+func TestBindSigningIdentity_ChoosingTheSecondAccountRecordsTheSecond(t *testing.T) {
+	writer := newFakeUsersWriter()
+	svc := newBindingService(&fakeRepo{}, writer)
+
+	// Choosing the first would pass even if selection were ignored entirely, which is the
+	// bug this feature exists to remove.
+	result, err := bind(svc, callerContext())
+
+	require.NoError(t, err)
+	assert.Equal(t, chosenGithubID, *result.GithubID)
+	assert.Equal(t, formatGithubID(chosenGithubID), writer.created[0].GithubID)
+}

--- a/docs/MY_CLAS_API.md
+++ b/docs/MY_CLAS_API.md
@@ -485,6 +485,131 @@ Each entry is `"<type>:<value>"`, deduplicated and sorted; types are `lf-usernam
 
 A token carrying no username returns `401` (same as the list endpoint).
 
+## `POST /v4/my-clas/signing-identity`
+
+Records which GitHub account a contributor is signing as on their EasyCLA user record, and
+returns the record identifier the Contributor Console hand-off consumes. Unlike the three
+endpoints above this one **writes**, and it is the only path in the service that may attach
+a GitHub account to a user record.
+
+```bash
+curl -X POST -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"githubId": 26589865, "githubUsername": "octocat"}' \
+  "$GW/cla-service/v4/my-clas/signing-identity"
+```
+
+### The submitted account is taken on trust
+
+This endpoint does not establish that the GitHub account belongs to the caller, and must
+not be read as though it does. Ownership is established by the calling service, which
+offers the contributor only the accounts the identity provider reports as linked to their
+session. What this endpoint verifies is **who is calling** — the gateway principal and the
+token's LF identity, which must agree — and **whether recording the account is safe given
+the records already held**.
+
+That second part is the whole of what bounds a mistaken or hostile submission, which is
+why none of the refusals below may be relaxed. An account held by another contributor's
+record is refused, an account on a record naming nobody is refused, and a caller whose own
+record already holds a different account is refused. What remains recordable is an account
+that appears nowhere in the store — the same exposure `PUT /v3/users` already carries,
+since it too persists a client-supplied `user_github_id`.
+
+`githubUsername` is optional and is never matched on, but it is recorded, because approval
+lists written against handles cannot match a record that has none. A blank value is
+treated as absent rather than written: recording an empty handle would replace whatever
+the record already held with nothing.
+
+### Resolution
+
+Lookup by **account number comes before any lookup by LF identity**, and the order is
+load-bearing. The authentication middleware creates an LF-only user record whenever its
+own lookups miss, unconditionally, and it runs before this handler on the same request.
+An LF-first resolution would therefore find that freshly created empty record and bind
+the account to it while a record keyed on that account already existed — producing two
+records holding one account, which sends the pull-request check to the wrong one.
+
+| Record holding the account | Then |
+|---|---|
+| Exactly one, same LF identity | Reused. The handle is refreshed if it was renamed; the account number is not rewritten |
+| Exactly one, **no** LF identity | Refused. See below |
+| Exactly one, different LF identity | Refused. Never reassigned |
+| More than one | Refused. `github-id-index` does not enforce uniqueness, so this is detected rather than assumed |
+| None, caller has no record | Created, carrying the LF identity, the account and the handle |
+| None, caller's record holds no account | Adopted — the account is recorded on it |
+| None, caller's record holds a different account | Refused. A record holds one account, and overwriting detaches the previous one |
+
+The second row is the one worth understanding before anyone "fixes" it. Such a record holds
+the account but names nobody, so the CLA signed onto it appears in no one's list. Writing
+the caller's LF identity onto it would reunite the rightful contributor with their own
+signature history — and, for anyone else, would hand them somebody else's, since the record
+carries signatures already. Telling those two cases apart needs proof of who owns the
+account, and the account number here is the caller's own submission. So it is refused, and
+the rate of that refusal measures how many contributors this costs.
+
+After resolving, the record is re-read and the account on it compared against the account
+submitted. That is a check on what the store accepted, not on whether the right account was
+chosen — this side cannot know the latter.
+
+That re-read is strongly consistent and goes to the base table. The lookup that resolved
+the record went through a global secondary index, which is always eventually consistent, so
+the record may no longer hold the account it was indexed under — precisely what this check
+is for. An eventually consistent confirmation could not tell that apart from its own stale
+view, and would refuse a contributor whose write had in fact succeeded.
+
+The recorded account is echoed in the response so the caller can make its own comparison,
+and callers are expected to make it before acting on the result. The two checks answer
+different questions: this service can only confirm the record holds the account it was
+*sent*, which is equally true if the caller sent the wrong one of the contributor's
+accounts. Only the caller knows which account the contributor picked.
+
+### Response — `200 signing-identity`
+
+```json
+{
+  "userId": "f1a2b3c4-1234-5678-90ab-cdef12345678",
+  "githubId": 26589865,
+  "githubUsername": "lukaszgryglicki",
+  "outcome": "matched"
+}
+```
+
+`outcome` is one of `matched`, `created`, `adopted` — observability only, not behavioural
+for the caller.
+
+### Refusals
+
+Each refusal carries its own reason code and is logged under it with `functionName` and
+`x-request-id`, so refusals are countable **by reason**. That matters because a contested
+account, an unclaimable record and a caller who already has an account recorded all look
+like "binding failed" while needing different responses from different people.
+
+| Status | Reason code | When |
+|---|---|---|
+| 403 | `identity_unavailable` | The request carries no LF identity to associate the account with |
+| 403 | `identity_mismatch` | The gateway-authenticated principal and the token's LF identity disagree. Should never occur; checked because the write uses the token's identity, so a disagreement would record the submitted account against a different person |
+| 409 | `record_conflict` | The account is held by a record belonging to a different LF identity |
+| 409 | `record_unclaimed` | The account is held by a record that names nobody; claiming it needs proof of ownership this endpoint does not have |
+| 409 | `duplicate_github_id` | More than one record holds the account number |
+| 409 | `lf_record_already_bound` | The caller's own record already holds a different account |
+| 409 | `recorded_mismatch` | What was recorded is not what was submitted, or the resolved record carries no identifier |
+| 500 | — | Repository or downstream failure |
+
+Every refusal that is decided before the write writes nothing — that is, all of them except
+`recorded_mismatch`, which by definition can only be reached after a write and does not undo
+it. A caller that receives `recorded_mismatch` must not read it as "nothing happened": the
+record may hold the account, and what failed is the confirmation that it holds the right one.
+Retrying is safe, since a record that already holds the submitted account resolves as a match.
+
+### The account number's type
+
+Integer everywhere this endpoint owns it — the swagger schema, the generated model, the
+service, and the caller's request body — and a decimal string only at the `users`
+repository seam, where `DBUser.UserGithubID` and `models.User.GithubID` are both strings
+and the repository converts to a DynamoDB `N` at the AttributeValue boundary. The update
+path marshals whatever it is given, so writing a string there would store an `S`
+attribute that the numeric key condition on `github-id-index` would never match again:
+the association would look correct in the record and be invisible to every lookup.
+
 ## How LFX Self Serve consumes this (M1 mapping)
 
 The SS server slice already on `lfx-self-serve` branch `feat/easycla-my-clas-server`


### PR DESCRIPTION
Adds `POST /v4/my-clas/signing-identity`, which records the GitHub account a contributor is signing with on their EasyCLA user record and returns the record identifier the Contributor Console hand-off consumes. Until now that identifier was whichever record an identity search matched first, which is neither the contributor's choice nor stable between signings.

Consumer side: [lfx-self-serve#1252](https://github.com/linuxfoundation/lfx-self-serve/issues/1252). Draft until that half is reviewed alongside it.

## The one thing to know before reading the rest

**This endpoint does not verify that the submitted GitHub account belongs to the caller.** That is deliberate. Ownership is established by LFX Self Serve, which offers a contributor only the accounts the identity provider reports as linked to their session and refuses a submitted account that is not among them. This service records that account on trust.

Read that way, the refusals below are the whole safety story rather than belt-and-braces, which is why none of them should be relaxed without replacing them.

What this endpoint *does* verify:

- **Who is calling.** The gateway-authenticated principal (`X-USERNAME`) must agree with the LF username in the caller's own verified Auth0 token. The write uses the token's identity, so a disagreement would record the account against a person the gateway did not authenticate — `identity_mismatch`, 403.
- **Whether recording is safe against the records that already exist**, via four refusals that each write nothing: the account is held by a record naming someone else (`record_conflict`); held by a record naming nobody (`record_unclaimed`); held by more than one record (`duplicate_github_id`); or the caller's own record already holds a different account (`lf_record_already_bound`).

## Notes for the reviewer

**A record holding the account but naming nobody is refused, not adopted.** Writing the caller's identity onto it would reunite the rightful contributor with their signature history — and would hand any other caller somebody else's, since such records already carry signatures. Telling those two apart needs proof of ownership this endpoint does not have, so it refuses. The cost is real and worth watching: contributors with detached records still cannot see those CLAs, and the `record_unclaimed` rate measures exactly how many.

**Resolution uses the `my_clas` repository's slice-returning lookups, not the `users` package's.** `GetUserByGitHubID`/`GetUserByLFUserName` warn and return the *first* of several matches, which would make `duplicate_github_id` unreachable and silently resolve a contested account to whichever record the index happened to return. They also disagree about how a miss looks — one returns `errors.NotFound`, the other `(nil, nil)`.

**The post-write confirmation is a strongly consistent read on the base table.** The resolving lookup goes through a GSI, which is always eventually consistent; confirming through the same path could not distinguish a genuine mismatch from its own stale view, and would refuse contributors whose write had in fact succeeded.

**`recorded_mismatch` is the one refusal that leaves a write behind.** It is only reachable after the write and does not undo it. A compensating delete would be a second unconfirmed write on a record the service has just lost confidence about, so it is documented rather than attempted. Retrying is safe: a record already holding the submitted account resolves as a match.

## Known and accepted

- **Squatting an unrecorded account number, and what that reaches.** For an account no record holds yet, none of the refusals apply, so a caller can bind a number that is not theirs and the rightful owner later meets `record_conflict`. This is worth stating more sharply than "a wrong label": the recorded handle is an authorization input, since `UserIsApproved` matches `user.GithubUsername` against a CCLA's `GithubUsernameApprovalList` (`signatures/service.go:1626-1630`). So a squatted binding can obtain approval-list membership under a company's CCLA. Deriving the handle from the number instead would not close it — squatting the victim's number yields the victim's handle and the same result. The vector is the absent ownership proof.

  Two things bound it. It is not a new door: `PUT /v3/users` already persists a client-supplied `user_github_id` **and** `user_github_username` with no ownership check, and its handler locates the record *by the submitted handle* before saving onto it (`users/handlers.go:85-107`, `users/repository.go:418-429`), which this endpoint refuses. And established bindings still cannot be reassigned. Watch the `record_conflict` rate.

- **This is why the PR is draft and why it should not land before [#5147](https://github.com/linuxfoundation/easycla/pull/5147).** Everything above rests on the endpoint being reachable only by Self Serve's confidential client, which is the premise #5147 enforces with `azp` allow-listing plus in-handler JWKS verification. Merging the binding endpoint first would ship the trust assumption ahead of the mechanism.
- **No conditional write between the resolve read and the write.** Two concurrent binders of the same unrecorded number can both succeed, creating the duplicate state a later call refuses on. Closing it needs a condition-carrying method on the shared `users` repository; detection is already in place. Both write paths now re-read the record on the base table first, so the window is the gap between that read and the write rather than GSI replication lag.

- **`lf_username` lookups are case-sensitive while the comparisons around them are not.** `lf-username-index` is queried with an exact key condition everywhere, including the shared `GetUserByLFUserName` that `createUserFromRequest` uses before this handler runs — and that middleware creates an LF-only record when its lookup misses. A case-variant record therefore already yields a duplicate through a path this PR does not touch. Resolving it means canonicalising `lf_username` on write plus a migration, which is a change to shared user-record handling.

## Test plan

- [ ] `make swagger && make build-mac && make test && make lint` — all green locally, including the license-header check
- [ ] 26 `BindSigningIdentity` tests cover each refusal, and assert on the stored record rather than only the error, so an implementation that writes and then errors cannot pass
- [ ] Deployed-environment checks still outstanding: gateway route coverage (a route the gateway does not guard receives no `X-ACL`), and seeded fixtures for a two-account contributor, a one-account contributor, and an unclaimed record
