### PR TITLE
Add Salesforce project and foundation ids to My CLAs rows (prod)

### DIFF
--- a/cla-backend-go/swagger/common/my-cla.yaml
+++ b/cla-backend-go/swagger/common/my-cla.yaml
@@ -25,6 +25,21 @@ properties:
   projectLogo:
     type: string
     description: Project (or foundation) logo URL, omitted when absent or unresolved
+  projectSFID:
+    type: string
+    description: >
+      Salesforce project id the CLA Group maps to. Omitted when the group is foundation-level
+      (use foundationSFID), when several project-level mappings have no foundation marker, or
+      when unresolved. Branch on which of the two ids is present rather than concatenating
+      them - both means project-level, /foundation/{foundationSFID}/project/{projectSFID}/cla;
+      foundationSFID alone means foundation-level; neither means unresolved, with no
+      addressable Corporate Console route
+  foundationSFID:
+    type: string
+    description: >
+      Salesforce foundation id. For a foundation-level CLA Group this is the Corporate Console
+      path /foundation/{foundationSFID}/cla. For a single project-level mapping it is the parent
+      foundation when the mapping table has one. Omitted when unresolved
   companyID:
     type: string
     description: Employer company ID (UUID), ECLA only

--- a/cla-backend-go/v2/my_clas/service.go
+++ b/cla-backend-go/v2/my_clas/service.go
@@ -191,10 +191,12 @@ func NewService(repo Repository, platformUsersService PlatformUsersService, sign
 	}
 }
 
-// projectInfo is the resolved Salesforce project display name and logo of a CLA Group
+// projectInfo is the resolved Salesforce project display name, logo, and ids of a CLA Group
 type projectInfo struct {
-	name string
-	logo string
+	name           string
+	logo           string
+	projectSFID    string
+	foundationSFID string
 }
 
 // GetMyClas returns the signed ICLAs and ECLAs of every EasyCLA user record matching the identity,
@@ -248,6 +250,8 @@ func (s *service) GetMyClas(ctx context.Context, caller *Caller, requested *Iden
 			ClaGroupName:         data.claGroupNames[sig.SignatureProjectID],
 			ProjectName:          project.name,
 			ProjectLogo:          project.logo,
+			ProjectSFID:          project.projectSFID,
+			FoundationSFID:       project.foundationSFID,
 			UserID:               sig.SignatureReferenceID,
 			SignedOn:             signedOn(sig),
 			Signed:               sig.SignatureSigned,
@@ -1197,10 +1201,11 @@ func (s *service) claGroupName(ctx context.Context, claGroupID string) (string, 
 	return name, nil
 }
 
-// projectInfo resolves the Salesforce project display name and logo of a CLA Group. The name comes
-// from the projects-cla-groups mapping, the logo only from the project-service, fetched by project
-// SFID (a foundation-level CLA Group resolves to its foundation). A lookup miss degrades to an
-// empty logo rather than failing the listing.
+// projectInfo resolves the Salesforce project display name, logo, and ids of a CLA Group. The
+// name comes from the projects-cla-groups mapping, the logo only from the project-service,
+// fetched by project SFID (a foundation-level CLA Group resolves to its foundation). A lookup
+// miss degrades to an empty logo rather than failing the listing. The ids are the ones the
+// Corporate Console path needs; they are omitted when the mapping is unresolved.
 func (s *service) projectInfo(ctx context.Context, claGroupID string) (projectInfo, error) {
 	if claGroupID == "" {
 		return projectInfo{}, nil
@@ -1212,29 +1217,32 @@ func (s *service) projectInfo(ctx context.Context, claGroupID string) (projectIn
 	}
 
 	var info projectInfo
-	var projectSFID string
+	var lookupSFID string
 	// A foundation-level CLA Group is marked by a mapping with ProjectSFID == FoundationSFID (the
 	// projects_cla_groups convention used by SignedAtFoundation), not by the mapping count, and
 	// resolves to its foundation; a single project-level mapping resolves to that project. Several
-	// project-level mappings with no foundation marker stay unresolved (empty name/logo, so the
+	// project-level mappings with no foundation marker stay unresolved (empty name/logo/ids, so the
 	// consumer falls back to claGroupName) rather than picking an arbitrary one.
 	switch fm := foundationMapping(mappings); {
 	case fm != nil:
-		projectSFID = fm.FoundationSFID
+		lookupSFID = fm.FoundationSFID
+		info.foundationSFID = fm.FoundationSFID
 		info.name = fm.FoundationName
 	case len(mappings) == 1:
-		projectSFID = mappings[0].ProjectSFID
+		lookupSFID = mappings[0].ProjectSFID
+		info.projectSFID = mappings[0].ProjectSFID
+		info.foundationSFID = mappings[0].FoundationSFID
 		info.name = mappings[0].ProjectName
 	}
 
-	if projectSFID != "" && s.projectService != nil {
+	if lookupSFID != "" && s.projectService != nil {
 		f := logrus.Fields{
 			"functionName":   "v2.my_clas.service.projectInfo",
 			utils.XREQUESTID: ctx.Value(utils.XREQUESTID),
 			"claGroupID":     claGroupID,
-			"projectSFID":    projectSFID,
+			"lookupSFID":     lookupSFID,
 		}
-		project, projectErr := s.projectService.GetProject(projectSFID)
+		project, projectErr := s.projectService.GetProject(lookupSFID)
 		if projectErr != nil {
 			log.WithFields(f).WithError(projectErr).Warn("unable to load the project details for the CLA group - leaving the logo empty")
 		} else if project != nil {

--- a/cla-backend-go/v2/my_clas/service_test.go
+++ b/cla-backend-go/v2/my_clas/service_test.go
@@ -300,8 +300,8 @@ func TestGetMyClasProjectNameAndLogo(t *testing.T) {
 	claGroups := &fakeClaGroups{
 		names: map[string]string{"cla-group-1": "Kubernetes CLA Group", "cla-group-2": "CNCF CLA Group"},
 		mappings: map[string][]*projects_cla_groups.ProjectClaGroup{
-			// single-project CLA Group -> resolves to the project SFID
-			"cla-group-1": {{ClaGroupID: "cla-group-1", ProjectSFID: "proj-sfid-1", ProjectName: "Kubernetes"}},
+			// single-project CLA Group -> resolves to the project SFID and its parent foundation
+			"cla-group-1": {{ClaGroupID: "cla-group-1", ProjectSFID: "proj-sfid-1", FoundationSFID: "found-parent", ProjectName: "Kubernetes"}},
 			// foundation-level CLA Group -> identified by the marker row (ProjectSFID == FoundationSFID)
 			// and resolves to the foundation SFID
 			"cla-group-2": {
@@ -329,11 +329,15 @@ func TestGetMyClasProjectNameAndLogo(t *testing.T) {
 	assert.Equal(t, "Kubernetes CLA Group", single.ClaGroupName, "the CLA group name is the subtext")
 	assert.Equal(t, "Kubernetes", single.ProjectName, "the project-service name wins over the mapping-table name")
 	assert.Equal(t, "https://logos.example.org/k8s.png", single.ProjectLogo)
+	assert.Equal(t, "proj-sfid-1", single.ProjectSFID)
+	assert.Equal(t, "found-parent", single.FoundationSFID)
 
 	foundation := byID["sig-foundation"]
 	assert.Equal(t, "CNCF CLA Group", foundation.ClaGroupName)
 	assert.Equal(t, "Cloud Native Computing Foundation", foundation.ProjectName, "a foundation-level CLA group resolves to its foundation")
 	assert.Equal(t, "https://logos.example.org/cncf.png", foundation.ProjectLogo)
+	assert.Equal(t, "found-sfid", foundation.FoundationSFID)
+	assert.Empty(t, foundation.ProjectSFID, "a foundation-level CLA group does not pick a child project")
 }
 
 func TestGetMyClasProjectLookupDegradesGracefully(t *testing.T) {
@@ -348,7 +352,7 @@ func TestGetMyClasProjectLookupDegradesGracefully(t *testing.T) {
 	claGroups := &fakeClaGroups{
 		names: map[string]string{"cla-group-1": "Kubernetes CLA Group"},
 		mappings: map[string][]*projects_cla_groups.ProjectClaGroup{
-			"cla-group-1": {{ClaGroupID: "cla-group-1", ProjectSFID: "proj-sfid-1", ProjectName: "Kubernetes"}},
+			"cla-group-1": {{ClaGroupID: "cla-group-1", ProjectSFID: "proj-sfid-1", FoundationSFID: "found-parent", ProjectName: "Kubernetes"}},
 		},
 	}
 	svc := newTestService(repo, &fakePlatform{}, &fakeSignatures{}, &fakeCompanies{}, claGroups)
@@ -359,6 +363,8 @@ func TestGetMyClasProjectLookupDegradesGracefully(t *testing.T) {
 	require.Len(t, result.Clas, 1)
 	assert.Equal(t, "Kubernetes", result.Clas[0].ProjectName, "the mapping-table name is kept when the project-service has no record")
 	assert.Empty(t, result.Clas[0].ProjectLogo, "a missing project logo degrades to empty")
+	assert.Equal(t, "proj-sfid-1", result.Clas[0].ProjectSFID, "the ids come from the mapping table, so a project-service miss does not drop them")
+	assert.Equal(t, "found-parent", result.Clas[0].FoundationSFID, "the ids come from the mapping table, so a project-service miss does not drop them")
 }
 
 // A CLA Group mapped to several projects with no foundation-marker row (no mapping where
@@ -392,6 +398,8 @@ func TestGetMyClasMultiProjectNonFoundation(t *testing.T) {
 	require.Len(t, result.Clas, 1)
 	assert.Empty(t, result.Clas[0].ProjectName, "an ambiguous multi-project non-foundation group invents no project name")
 	assert.Empty(t, result.Clas[0].ProjectLogo, "an ambiguous multi-project non-foundation group invents no project logo")
+	assert.Empty(t, result.Clas[0].ProjectSFID)
+	assert.Empty(t, result.Clas[0].FoundationSFID)
 	assert.Equal(t, "Multi CLA Group", result.Clas[0].ClaGroupName, "the consumer falls back to claGroupName")
 }
 

--- a/docs/MY_CLAS_API.md
+++ b/docs/MY_CLAS_API.md
@@ -424,6 +424,8 @@ date), and the listing never clears a flag. The first persist of a new sanction 
       "claGroupName": "CNCF - Kubernetes",
       "projectName": "Kubernetes",
       "projectLogo": "https://.../kubernetes.svg",
+      "projectSFID": "a09P000000DsCE6IAN",
+      "foundationSFID": "a09P000000DsCE5IAN",
       "userID": "6e29e1a9-...",
       "signedOn": "2025-11-03T10:22:00Z",
       "signed": true,
@@ -469,6 +471,8 @@ Field reference (`my-cla` rows):
 | `claGroupName` | string | From the `projects_cla_groups` repo (single `GetItem`, cached per request); **omitted from the JSON** (string fields marshal with `omitempty`) when the CLA group record is gone — closes the "payload carries no project display name" gap from M1 research R6. No v1 user-service/org-service IDs are exposed (architecture-proposal P9) |
 | `projectName` | string | Salesforce project display name of the CLA Group (a foundation-level CLA Group — a `projects_cla_groups` mapping whose `project_sfid == foundation_sfid` — resolves to its foundation). From the mapping table, upgraded to the project-service `Name` when available; both cached per request. Bold top line of the UI's Project cell, with `claGroupName` as subtext. Omitted when unresolved |
 | `projectLogo` | string | Project (or foundation) logo URL from the project-service by project SFID (cached per request). The Project cell's logo tile (the consumer supplies the default-icon fallback). A miss degrades to an empty logo without failing the listing; omitted when empty |
+| `projectSFID` | string | Salesforce project id of the single `projects_cla_groups` mapping. Omitted on a foundation-level CLA Group, on a multi-project group with no foundation marker, and when unresolved |
+| `foundationSFID` | string | Salesforce foundation id — the marker row's `foundation_sfid` on a foundation-level CLA Group, otherwise the single mapping's parent foundation. Omitted when unresolved. **Branch on which of the two ids is present rather than concatenating them**: both ⇒ project-level (`/foundation/{foundationSFID}/project/{projectSFID}/cla`), `foundationSFID` alone ⇒ foundation-level (`/foundation/{foundationSFID}/cla`), neither ⇒ unresolved, so the consumer has no addressable Corporate Console route |
 | `companyID` / `companyName` / `signingEntityName` | string | ECLA only; from the companies table (cached per request) |
 | `userID` | string | The owning EasyCLA user record — correlates rows with `userIds` and with other per-user endpoints |
 | `signedOn` | string | Signing/acknowledgement date (fallback: record creation date) |
@@ -613,7 +617,11 @@ missing lookup endpoint. With this API it collapses to:
   `MyClaAgreement`: `kind = claType`, `projectName = projectName` (bold top line of the
   Project cell) with `claGroupName` as subtext and `projectLogo` as the logo tile (falling
   back to `claGroupName` / a default icon when absent — the old
-  `projectName = claGroupName` UUID fallback is retired), the status pill from
+  `projectName = claGroupName` UUID fallback is retired), `projectSfid = projectSFID` and
+  `foundationSfid = foundationSFID` (the Corporate CLA Console deep link behind My CLAs'
+  "Manage in CCLA Console" kebab item —
+  [#1575](https://github.com/linuxfoundation/lfx-self-serve/issues/1575) — which falls back to
+  the company dashboard when no `foundationSFID` arrives), the status pill from
   `status`/`statusReason` (`valid` stays the boolean shortcut but is **not** the display
   filter — see step 4), `pdfAvailable` as-is; identity telemetry from `userIds` and
   `skippedIdentities` (`matchedUserIds = userIds.length`, and


### PR DESCRIPTION
Promotes linuxfoundation/easycla#5158 to PROD.

## What

`GET /v4/my-clas` now returns two optional fields on each row: `projectSFID` and `foundationSFID`.

## Why

The endpoint already resolves the Salesforce ids of a CLA Group's `projects_cla_groups` mapping in
order to fetch `projectName` and `projectLogo`, then throws them away. Consumers are left with no way
to address the CLA Group in the LFX Corporate CLA Console.

The immediate consumer is LFX Self Serve's My CLAs page, which is adding a "Manage in CCLA Console"
link for CLA managers — linuxfoundation/lfx-self-serve#1575.

## Contract

Presence is the discriminator. Consumers branch on which ids arrived rather than concatenating them:

| Mapping shape | `foundationSFID` | `projectSFID` | Console route |
|---|---|---|---|
| Foundation-level (marker row where `project_sfid == foundation_sfid`) | set | omitted | `/foundation/{foundationSFID}/cla` |
| Single project-level mapping | set | set | `/foundation/{foundationSFID}/project/{projectSFID}/cla` |
| Several project-level mappings, no foundation marker | omitted | omitted | none — unresolved |

A foundation-level group deliberately omits `projectSFID` rather than echoing the foundation id into
both, so a consumer can tell "foundation" apart from "project under a foundation" without comparing
ids. This matches `emails.CLAProjectParams.GetProjectFullURL`, which ignores `ProjectSFID` entirely
on its foundation branch. The unresolved case matches how `projectName` and `projectLogo` already
behave.

Both fields marshal with `omitempty`, so existing clients see no change.

## Changes

- `swagger/common/my-cla.yaml` — declares both fields, with the branching rule in the description.
- `v2/my_clas/service.go` — `projectInfo` retains the ids it already computed; `GetMyClas` copies
  them onto `models.MyCla`. The local driving the project-service lookup is renamed `projectSFID` →
  `lookupSFID`, since it can hold a foundation id; its log field key follows.
- `docs/MY_CLAS_API.md` — sample body, field reference, and the Self Serve mapping section.

The four changed files are byte-identical to `dev` (merged in #5158), where `make fmt`, `make build-mac`, `make test`, and `make lint` passed. Cherry-picked as `ecc6d7df7` from `71e8c4268`. `./v2/my_clas` tests re-ran clean on this branch.

Note: `main` CI does not run build/test/lint, and `make swagger` regenerates `models.MyCla.{ProjectSFID,FoundationSFID}` at deploy time from the edited `my-cla.yaml`.