### PR TITLE
Fix base58 names for auth0 identities + guard approval-list invalidation against missing user records

### DIFF
--- a/cla-backend-go/go.mod
+++ b/cla-backend-go/go.mod
@@ -70,6 +70,7 @@ require (
 )
 
 require (
+	github.com/akamensky/base58 v0.0.0-20210829145138-ce8bf8802e8f
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.53.1
 	github.com/bradleyfalzon/ghinstallation/v2 v2.2.0
 	github.com/golang-jwt/jwt/v4 v4.5.2

--- a/cla-backend-go/go.sum
+++ b/cla-backend-go/go.sum
@@ -53,6 +53,8 @@ github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
+github.com/akamensky/base58 v0.0.0-20210829145138-ce8bf8802e8f h1:z8MkSJCUyTmW5YQlxsMLBlwA7GmjxC7L4ooicxqnhz8=
+github.com/akamensky/base58 v0.0.0-20210829145138-ce8bf8802e8f/go.mod h1:UdUwYgAXBiL+kLfcqxoQJYkHA/vl937/PbFhZM34aZs=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=

--- a/cla-backend-go/signatures/repository.go
+++ b/cla-backend-go/signatures/repository.go
@@ -4291,6 +4291,12 @@ func (repo repository) invalidateSignatures(ctx context.Context, approvalList *A
 		for _, icla := range approvalList.ICLAs {
 			go func(icla *models.IclaSignature) {
 				defer iclaWg.Done()
+				// a panic in this goroutine would kill the whole process - contain it here
+				defer func() {
+					if r := recover(); r != nil {
+						log.WithFields(f).Errorf("recovered from panic while invalidating signature: %s - skipping record: %v", icla.SignatureID, r)
+					}
+				}()
 				signature, sigErr := repo.GetSignature(ctx, icla.SignatureID)
 				if sigErr != nil {
 					log.WithFields(f).Warnf("unable to fetch signature for ID: %s ", icla.SignatureID)
@@ -4338,6 +4344,12 @@ func (repo repository) invalidateSignatures(ctx context.Context, approvalList *A
 		for _, ecla := range approvalList.ECLAs {
 			go func(ecla *models.Signature) {
 				defer eclaWg.Done()
+				// a panic in this goroutine would kill the whole process - contain it here
+				defer func() {
+					if r := recover(); r != nil {
+						log.WithFields(f).Errorf("recovered from panic while invalidating signature: %s - skipping record: %v", ecla.SignatureID, r)
+					}
+				}()
 				// Grab user record
 				if ecla.SignatureReferenceID == "" {
 					log.WithFields(f).Warnf("no signatureReferenceID for signature: %+v ", ecla)
@@ -4385,6 +4397,12 @@ func (repo repository) verifyUserApprovals(ctx context.Context, userID, signatur
 	if err != nil {
 		log.WithFields(f).Warnf("unable to get user record for ID: %s ", userID)
 		return nil, false, err
+	}
+	// GetUser returns (nil, nil) for a missing record - historical signatures may reference
+	// deleted users, and invalidating what we cannot re-check would be destructive
+	if user == nil {
+		log.WithFields(f).Warnf("user record not found for ID: %s - skipping approval re-check for signature: %s", userID, signatureID)
+		return nil, false, nil
 	}
 	email := getBestEmail(user)
 	invalidationMetadata := &InvalidationMetadata{
@@ -4493,6 +4511,9 @@ func effectiveApprovals(current, add, remove []string) []string {
 // effectiveApprovals). GitHub/GitLab org membership is not re-checked here, consistent with
 // the sibling criteria branches.
 func userStillApproved(user *models.User, approvalList *ApprovalList) bool {
+	if user == nil {
+		return false
+	}
 	var emails []string
 	emails = append(emails, user.Emails...)
 	if user.LfEmail != "" {

--- a/cla-backend-go/signatures/repository.go
+++ b/cla-backend-go/signatures/repository.go
@@ -4192,6 +4192,9 @@ func (repo repository) sendEmail(ctx context.Context, email string, approvalList
 // have no company link, so a corporate approved list edit must not touch them (#5166).
 const invalidateICLAsOnApprovalListRemoval = false
 
+// nilSignatureEntry labels a nil signature slice entry in the panic-recovery logs
+const nilSignatureEntry = "<nil entry>"
+
 // employeeSignatureListed reports whether the given user already has an employee signature in the list
 func employeeSignatureListed(eclas []*models.Signature, userID string) bool {
 	for _, ecla := range eclas {
@@ -4291,12 +4294,21 @@ func (repo repository) invalidateSignatures(ctx context.Context, approvalList *A
 		for _, icla := range approvalList.ICLAs {
 			go func(icla *models.IclaSignature) {
 				defer iclaWg.Done()
-				// a panic in this goroutine would kill the whole process - contain it here
+				// a panic in this goroutine would kill the whole process - contain it here,
+				// without dereferencing anything that could re-panic inside the handler
 				defer func() {
 					if r := recover(); r != nil {
-						log.WithFields(f).Errorf("recovered from panic while invalidating signature: %s - skipping record: %v", icla.SignatureID, r)
+						sigID := nilSignatureEntry
+						if icla != nil {
+							sigID = icla.SignatureID
+						}
+						log.WithFields(f).Errorf("recovered from panic while invalidating signature: %s - skipping record: %v", sigID, r)
 					}
 				}()
+				if icla == nil {
+					log.WithFields(f).Warn("nil icla entry - skipping")
+					return
+				}
 				signature, sigErr := repo.GetSignature(ctx, icla.SignatureID)
 				if sigErr != nil {
 					log.WithFields(f).Warnf("unable to fetch signature for ID: %s ", icla.SignatureID)
@@ -4344,12 +4356,21 @@ func (repo repository) invalidateSignatures(ctx context.Context, approvalList *A
 		for _, ecla := range approvalList.ECLAs {
 			go func(ecla *models.Signature) {
 				defer eclaWg.Done()
-				// a panic in this goroutine would kill the whole process - contain it here
+				// a panic in this goroutine would kill the whole process - contain it here,
+				// without dereferencing anything that could re-panic inside the handler
 				defer func() {
 					if r := recover(); r != nil {
-						log.WithFields(f).Errorf("recovered from panic while invalidating signature: %s - skipping record: %v", ecla.SignatureID, r)
+						sigID := nilSignatureEntry
+						if ecla != nil {
+							sigID = ecla.SignatureID
+						}
+						log.WithFields(f).Errorf("recovered from panic while invalidating signature: %s - skipping record: %v", sigID, r)
 					}
 				}()
+				if ecla == nil {
+					log.WithFields(f).Warn("nil ecla entry - skipping")
+					return
+				}
 				// Grab user record
 				if ecla.SignatureReferenceID == "" {
 					log.WithFields(f).Warnf("no signatureReferenceID for signature: %+v ", ecla)

--- a/cla-backend-go/signatures/repository_test.go
+++ b/cla-backend-go/signatures/repository_test.go
@@ -80,6 +80,11 @@ func TestUserStillApproved(t *testing.T) {
 		GitlabUsername: "janegl",
 	}
 
+	// a missing user record can never count as approved
+	assert.False(t, userStillApproved(nil, &ApprovalList{
+		EmailApprovals: []string{"jane@corp.example"},
+	}))
+
 	// GH username removed but still on the email approved list (the #5166 scenario)
 	assert.True(t, userStillApproved(user, &ApprovalList{
 		EmailApprovals: []string{"jane@corp.example"},

--- a/cla-backend-go/signatures/repository_test.go
+++ b/cla-backend-go/signatures/repository_test.go
@@ -4,11 +4,15 @@
 package signatures
 
 import (
+	"context"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/linuxfoundation/easycla/cla-backend-go/gen/v1/models"
+	mock_users "github.com/linuxfoundation/easycla/cla-backend-go/users/mocks"
+	"github.com/linuxfoundation/easycla/cla-backend-go/utils"
 )
 
 func TestInvalidationUpdateExpression(t *testing.T) {
@@ -69,6 +73,43 @@ func TestEffectiveApprovals(t *testing.T) {
 	// removals stay exact-match on raw entries (persistence parity): a padded remove entry
 	// removes nothing
 	assert.Equal(t, []string{"a"}, effectiveApprovals([]string{"a"}, nil, []string{" a "}))
+}
+
+// a panic inside an invalidation goroutine must never escape - the non-nil entry reaches
+// verifyUserApprovals, panics on the nil usersRepo, and recover contains it; the nil entry
+// exercises the nil-skip and the nil-safe recovery logging. The ICLA loop shares the same
+// containment but is compile-time disabled (invalidateICLAsOnApprovalListRemoval), so only
+// the ECLA loop is exercisable here.
+func TestInvalidateSignaturesPanicContainment(t *testing.T) {
+	repo := repository{}
+	eclas := []*models.Signature{
+		nil,
+		{SignatureID: "sig-1", SignatureReferenceID: "user-1", ProjectID: "p"},
+	}
+
+	icla, ecla := repo.invalidateSignatures(context.Background(),
+		&ApprovalList{Criteria: utils.EmailDomainCriteria, ECLAs: eclas},
+		&models.User{}, nil)
+
+	assert.Empty(t, icla)
+	assert.Empty(t, ecla)
+}
+
+// a missing user record (GetUser returning nil, nil) must skip the re-check without error
+// and without invalidating - invalidation would nil-panic on the repository's dynamoDBClient
+func TestVerifyUserApprovalsMissingUser(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockUsers := mock_users.NewMockUserRepository(ctrl)
+	mockUsers.EXPECT().GetUser("missing-user").Return(nil, nil)
+	repo := repository{usersRepo: mockUsers}
+
+	user, invalidated, err := repo.verifyUserApprovals(context.Background(),
+		"missing-user", "sig-1", &models.User{}, &ApprovalList{Criteria: utils.EmailDomainCriteria})
+
+	assert.Nil(t, user)
+	assert.False(t, invalidated)
+	assert.NoError(t, err)
 }
 
 // userStillApproved receives approval lists that already reflect the full pending update

--- a/cla-backend-go/signatures/repository_test.go
+++ b/cla-backend-go/signatures/repository_test.go
@@ -87,8 +87,14 @@ func TestInvalidateSignaturesPanicContainment(t *testing.T) {
 		{SignatureID: "sig-1", SignatureReferenceID: "user-1", ProjectID: "p"},
 	}
 
+	// the ICLA entry proves the disabled-invalidation contract: with
+	// invalidateICLAsOnApprovalListRemoval false the loop is never entered
 	icla, ecla := repo.invalidateSignatures(context.Background(),
-		&ApprovalList{Criteria: utils.EmailDomainCriteria, ECLAs: eclas},
+		&ApprovalList{
+			Criteria: utils.EmailDomainCriteria,
+			ICLAs:    []*models.IclaSignature{{SignatureID: "icla-1"}},
+			ECLAs:    eclas,
+		},
 		&models.User{}, nil)
 
 	assert.Empty(t, icla)

--- a/cla-backend-go/v2/my_clas/auth0_identities.go
+++ b/cla-backend-go/v2/my_clas/auth0_identities.go
@@ -6,16 +6,39 @@ package my_clas
 import (
 	"bytes"
 	"context"
+	"crypto/sha512"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/akamensky/base58"
+	"github.com/sirupsen/logrus"
+
+	log "github.com/linuxfoundation/easycla/cla-backend-go/logging"
+	"github.com/linuxfoundation/easycla/cla-backend-go/utils"
 )
+
+// mirrors lfx-v2-auth-service's mapUsernameToSub: LF usernames Auth0 cannot hold verbatim are
+// stored under base58(sha512(username)) instead
+var (
+	auth0SafeNameRE = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,58}[A-Za-z0-9]$`)
+	auth0HexUserRE  = regexp.MustCompile(`^[0-9a-f]{24,60}$`)
+)
+
+func auth0UserID(lfUsername string) string {
+	if auth0SafeNameRE.MatchString(lfUsername) && !auth0HexUserRE.MatchString(lfUsername) {
+		return lfUsername
+	}
+	hash := sha512.Sum512([]byte(lfUsername))
+	return base58.Encode(hash[:])
+}
 
 // Auth0Identity is one identity linked to the LF login's Auth0 user record
 type Auth0Identity struct {
@@ -69,8 +92,9 @@ func (c *auth0Client) UserIdentities(ctx context.Context, lfUsername string) ([]
 	if err != nil {
 		return nil, err
 	}
+	auth0ID := "auth0|" + auth0UserID(lfUsername)
 	endpoint := fmt.Sprintf("%s/api/v2/users/%s?fields=identities&include_fields=true",
-		c.baseURL, url.PathEscape("auth0|"+lfUsername))
+		c.baseURL, url.PathEscape(auth0ID))
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return nil, err
@@ -82,6 +106,12 @@ func (c *auth0Client) UserIdentities(ctx context.Context, lfUsername string) ([]
 	}
 	defer resp.Body.Close() // nolint:errcheck
 	if resp.StatusCode == http.StatusNotFound {
+		log.WithFields(logrus.Fields{
+			"functionName":   "v2.my_clas.auth0Client.UserIdentities",
+			utils.XREQUESTID: ctx.Value(utils.XREQUESTID),
+			"lfUsername":     lfUsername,
+			"auth0UserID":    auth0ID,
+		}).Warn("no Auth0 user record for the LF username - skipping the Auth0 identity source")
 		return nil, nil
 	}
 	if resp.StatusCode != http.StatusOK {

--- a/cla-backend-go/v2/my_clas/auth0_identities_test.go
+++ b/cla-backend-go/v2/my_clas/auth0_identities_test.go
@@ -74,6 +74,41 @@ func TestAuth0UserIdentities(t *testing.T) {
 	assert.Nil(t, identities)
 }
 
+// golden hashes produced with lfx-v2-auth-service's mapUsernameToSub implementation
+func TestAuth0UserID(t *testing.T) {
+	assert.Equal(t, "someone", auth0UserID("someone"))
+	assert.Equal(t, "Some.One-1_x", auth0UserID("Some.One-1_x"))
+	// unsafe shapes (legacy LDAP usernames) map to base58(sha512(username))
+	assert.Equal(t, "5kMCBMmM1Nz41roKkv37FeGJnEUxTVQtbWyE7Ead97tr53jpRf4Z5YT3wbmey1qnhdPacvvU5Aw81arBof2ZnoAD",
+		auth0UserID("Lonnie K"))
+	assert.Equal(t, "27tAPEA6iekKLujHgDMmq6EwyezNnhKPcyNcxkQeCNZ8ZGyar6hQU5zmiCDSginEtJiWAKEFz2gFoyfzfryDdwX6",
+		auth0UserID("victord 14"))
+	// 24-60 lowercase hex chars collide with Auth0-generated IDs, so they hash too
+	assert.Equal(t, "2Ub9T1AHtbbBbaj4QcsdXmR5Gp1HZyYE7jR3mc6qcqq11u99JJbTHXHdXeLftcPwYLJNR4u8shKqXRGD2bEXpF2A",
+		auth0UserID("abcdef0123456789abcdef01"))
+	// single-character names fail the safe pattern and hash
+	assert.NotEqual(t, "a", auth0UserID("a"))
+}
+
+func TestAuth0UserIdentitiesUnsafeUsernamePath(t *testing.T) {
+	var requestedPath string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/oauth/token", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"access_token":"test-token","expires_in":86400}`)) // nolint:errcheck
+	})
+	mux.HandleFunc("/api/v2/users/", func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.EscapedPath()
+		_, _ = w.Write([]byte(`{"identities":[]}`)) // nolint:errcheck
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	svc := NewAuth0IdentityService(server.URL+"/oauth/token", "id", "secret")
+
+	_, err := svc.UserIdentities(context.Background(), "Lonnie K")
+	require.NoError(t, err)
+	assert.Equal(t, "/api/v2/users/auth0%7C"+auth0UserID("Lonnie K"), requestedPath)
+}
+
 func TestAuth0UserIdentitiesNotFound(t *testing.T) {
 	tokenCalls := 0
 	server := newAuth0TestServer(t, &tokenCalls, http.StatusNotFound, `{"error":"Not Found"}`)


### PR DESCRIPTION
cc @mlehotskylf @ahmedomosanya 

Signed-off-by: Łukasz Gryglicki <lgryglicki@cncf.io>

Assisted by [OpenAI](https://platform.openai.com/)

Assisted by [GitHub Copilot](https://github.com/features/copilot)

Assisted by [Claude](https://claude.ai)

---

## Expanded scope: approval-list invalidation hardening (bundled fast-track fix)

Besides the Auth0 base58 identity mapping, this PR also fixes a lambda-killing regression shipped in #5172: the now-active domain-removal branch fans out over company ECLAs; a dangling `signature_reference_id` (user record deleted; a legacy `signature_type: "cla"` employee row) made `GetUser` return `(nil, nil)` and the re-check code dereferenced it inside a goroutine — the panic killed the whole v4 API lambda (502 + lost approval-list update; CloudWatch stacks at `repository.go:4405` via `:4346`; cypress "Remove domain from Approval List" red on every run since the merge deployed).

Fix: treat missing user records as "cannot re-check → skip, never invalidate", plus defer/recover containment (with nil-safe logging and nil-entry skips) in both invalidation loops so no future data quirk can take the API down. Tests: missing-user policy, panic containment, and the disabled-ICLA-invalidation contract.

Bundled here (rather than a separate PR) to fast-track: prod runs the same crash since v2.9.4. After deploy, `v4/signatures.cy.ts` should return to 37/37 — the single red cypress spec on this PR is that very deployed-dev panic (the workflow tests the currently deployed dev API, not this PR's code).
