### PR TITLE
EasyCLA/SS M3 - bug fixes

### DIFF
--- a/cla-backend-go/cla_manager/service.go
+++ b/cla-backend-go/cla_manager/service.go
@@ -217,6 +217,7 @@ func (s service) AddClaManager(ctx context.Context, authUser *auth.User, company
 	if projectErr != nil || claGroupModel == nil {
 		return nil, projectErr
 	}
+	projectSFName = claGroupModel.ProjectName
 
 	// Look up signature ACL to ensure the user can add cla manager
 
@@ -337,6 +338,7 @@ func (s service) RemoveClaManager(ctx context.Context, authUser *auth.User, comp
 	if projectErr != nil || claGroupModel == nil {
 		return nil, projectErr
 	}
+	projectSFName = claGroupModel.ProjectName
 
 	signed := true
 	approved := true

--- a/cla-backend-go/company/models.go
+++ b/cla-backend-go/company/models.go
@@ -5,6 +5,7 @@ package company
 
 import (
 	"context"
+	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/linuxfoundation/easycla/cla-backend-go/gen/v1/models"
@@ -104,7 +105,10 @@ func (dbCompanyModel *DBModel) toModel() (*models.Company, error) {
 	}, nil
 }
 
-// dbModelsToResponseModels is a helper routine to convert the (internal) database model to a (public) swagger model
+// dbModelsToResponseModels converts DB rows to swagger models. includeChildCompanies=true
+// returns every row (the org lens). includeChildCompanies=false returns exactly one
+// deterministic "parent" row: duplicate rows per SFID are a known data issue (separate merge
+// runbook), so ties are broken by oldest date_created then smallest company_id, and are logged.
 func dbModelsToResponseModels(ctx context.Context, dbModels []DBModel, includeChildCompanies bool) ([]*models.Company, error) {
 	f := logrus.Fields{
 		"functionName":          "company.models.dbModelsToResponseModels",
@@ -113,27 +117,64 @@ func dbModelsToResponseModels(ctx context.Context, dbModels []DBModel, includeCh
 	}
 
 	var companyModels []*models.Company
+	var all, candidates []*models.Company
 	var err error
 	for _, dbModel := range dbModels {
 		respModel, conversionErr := dbModel.toModel()
 		if conversionErr != nil {
 			log.WithFields(f).WithError(conversionErr).Warn("unable to convert db model to company model")
 			err = conversionErr
-		} else {
-			// log.WithFields(f).Debugf("Converted %+v to %+v", dbModel, respModel)
-			if includeChildCompanies {
-				companyModels = append(companyModels, respModel)
-			} else {
-				// only include if company is not a signing entity name with different name
-				if respModel.SigningEntityName == "" || respModel.CompanyName == respModel.SigningEntityName {
-					companyModels = append(companyModels, respModel)
-					break // no need to continue
-				}
-			}
+			continue
+		}
+		if includeChildCompanies {
+			companyModels = append(companyModels, respModel)
+			continue
+		}
+		all = append(all, respModel)
+		// only a candidate if company is not a signing entity name with a different name
+		if respModel.SigningEntityName == "" || respModel.CompanyName == respModel.SigningEntityName {
+			candidates = append(candidates, respModel)
 		}
 	}
+	if includeChildCompanies {
+		return companyModels, err
+	}
+	if len(all) == 0 {
+		return companyModels, err // every row (if any) failed conversion
+	}
 
-	return companyModels, err
+	pick := candidates
+	if len(pick) == 0 {
+		// Rows exist for this SFID, just none look like a bare "parent" record - still a real
+		// company (the org lens lists these same rows), so fall back across all of them instead
+		// of reporting company-not-found.
+		log.WithFields(f).Warnf("no parent-like company record for this SFID - falling back across %d signing-entity row(s)", len(all))
+		pick = all
+	}
+	winner := pick[0]
+	for _, c := range pick[1:] {
+		if companyIsOlder(c, winner) {
+			winner = c
+		}
+	}
+	if len(pick) > 1 {
+		ids := make([]string, 0, len(pick))
+		for _, c := range pick {
+			ids = append(ids, c.CompanyID)
+		}
+		log.WithFields(f).WithField("candidateCompanyIDs", ids).Warn("multiple company records share this external SFID - picked deterministically, remaining need a data merge")
+	}
+	return []*models.Company{winner}, nil
+}
+
+// companyIsOlder reports whether c predates winner, tie-breaking on the smaller company_id so
+// repeated calls return the same row.
+func companyIsOlder(c, winner *models.Company) bool {
+	ct, wt := time.Time(c.Created), time.Time(winner.Created)
+	if !ct.Equal(wt) {
+		return ct.Before(wt)
+	}
+	return c.CompanyID < winner.CompanyID
 }
 
 // toModel is a helper routine to convert the (internal) database model to a (public) swagger model

--- a/cla-backend-go/company/models.go
+++ b/cla-backend-go/company/models.go
@@ -137,6 +137,9 @@ func dbModelsToResponseModels(ctx context.Context, dbModels []DBModel, includeCh
 		}
 	}
 	if includeChildCompanies {
+		if len(companyModels) > 0 {
+			return companyModels, nil
+		}
 		return companyModels, err
 	}
 	if len(all) == 0 {

--- a/cla-backend-go/company/models_test.go
+++ b/cla-backend-go/company/models_test.go
@@ -95,6 +95,29 @@ func TestDbModelsToResponseModels(t *testing.T) {
 		assert.Equal(t, "id-3", result[2].CompanyID)
 	})
 
+	t.Run("includeChildCompanies true skips bad rows and returns the rest without error", func(t *testing.T) {
+		rows := []DBModel{
+			parent("id-bad", "Acme", "not-a-date"),
+			parent("id-1", "Acme", "2019-01-01T00:00:00Z"),
+			signingEntity("id-2", "Acme", "Acme Sub LLC", "2020-01-01T00:00:00Z"),
+		}
+		result, err := dbModelsToResponseModels(ctx, rows, true)
+		require.NoError(t, err, "one corrupt row must not poison the org-lens listing")
+		require.Len(t, result, 2)
+		assert.Equal(t, "id-1", result[0].CompanyID)
+		assert.Equal(t, "id-2", result[1].CompanyID)
+	})
+
+	t.Run("includeChildCompanies true all rows fail conversion returns error and empty list", func(t *testing.T) {
+		rows := []DBModel{
+			parent("id-1", "Acme", "not-a-date"),
+			parent("id-2", "Acme", "also-not-a-date"),
+		}
+		result, err := dbModelsToResponseModels(ctx, rows, true)
+		assert.Error(t, err)
+		assert.Empty(t, result)
+	})
+
 	t.Run("unparsable date row skipped and valid rows still resolve without error", func(t *testing.T) {
 		rows := []DBModel{
 			parent("id-bad", "Acme", "not-a-date"),

--- a/cla-backend-go/company/models_test.go
+++ b/cla-backend-go/company/models_test.go
@@ -1,0 +1,119 @@
+// Copyright The Linux Foundation and each contributor to CommunityBridge.
+// SPDX-License-Identifier: MIT
+
+package company
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDbModelsToResponseModels(t *testing.T) {
+	ctx := context.Background()
+
+	parent := func(id, name, created string) DBModel {
+		return DBModel{
+			CompanyID:         id,
+			CompanyName:       name,
+			SigningEntityName: name,
+			CompanyExternalID: "0014100000TestSFID",
+			Created:           created,
+			Updated:           created,
+		}
+	}
+	signingEntity := func(id, name, entityName, created string) DBModel {
+		return DBModel{
+			CompanyID:         id,
+			CompanyName:       name,
+			SigningEntityName: entityName,
+			CompanyExternalID: "0014100000TestSFID",
+			Created:           created,
+			Updated:           created,
+		}
+	}
+
+	t.Run("single row unchanged", func(t *testing.T) {
+		result, err := dbModelsToResponseModels(ctx, []DBModel{parent("id-1", "Acme", "2020-01-01T00:00:00Z")}, false)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, "id-1", result[0].CompanyID)
+	})
+
+	t.Run("multiple parent candidates picks oldest regardless of order", func(t *testing.T) {
+		older := parent("id-b", "Acme", "2019-06-15T00:00:00Z")
+		newer := parent("id-a", "Acme", "2021-03-01T00:00:00Z")
+		variant := signingEntity("id-c", "Acme", "Acme Sub LLC", "2018-01-01T00:00:00Z")
+
+		for _, rows := range [][]DBModel{
+			{newer, older, variant},
+			{variant, newer, older},
+		} {
+			result, err := dbModelsToResponseModels(ctx, rows, false)
+			require.NoError(t, err)
+			require.Len(t, result, 1)
+			assert.Equal(t, "id-b", result[0].CompanyID, "oldest parent-like row must win for input order %v", rows)
+		}
+	})
+
+	t.Run("tie on date_created breaks on smallest company_id", func(t *testing.T) {
+		a := parent("id-aaa", "Acme", "2020-01-01T00:00:00Z")
+		b := parent("id-bbb", "Acme", "2020-01-01T00:00:00Z")
+
+		for _, rows := range [][]DBModel{{a, b}, {b, a}} {
+			result, err := dbModelsToResponseModels(ctx, rows, false)
+			require.NoError(t, err)
+			require.Len(t, result, 1)
+			assert.Equal(t, "id-aaa", result[0].CompanyID)
+		}
+	})
+
+	t.Run("no parent candidate falls back across all rows without error", func(t *testing.T) {
+		rows := []DBModel{
+			signingEntity("id-2", "Acme", "Acme Sub LLC", "2021-01-01T00:00:00Z"),
+			signingEntity("id-1", "Acme", "Acme Holdings", "2019-01-01T00:00:00Z"),
+		}
+		result, err := dbModelsToResponseModels(ctx, rows, false)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, "id-1", result[0].CompanyID, "oldest row wins in the all-rows fallback")
+	})
+
+	t.Run("includeChildCompanies true returns all rows unchanged", func(t *testing.T) {
+		rows := []DBModel{
+			parent("id-1", "Acme", "2019-01-01T00:00:00Z"),
+			parent("id-2", "Acme", "2020-01-01T00:00:00Z"),
+			signingEntity("id-3", "Acme", "Acme Sub LLC", "2021-01-01T00:00:00Z"),
+		}
+		result, err := dbModelsToResponseModels(ctx, rows, true)
+		require.NoError(t, err)
+		require.Len(t, result, 3)
+		assert.Equal(t, "id-1", result[0].CompanyID)
+		assert.Equal(t, "id-2", result[1].CompanyID)
+		assert.Equal(t, "id-3", result[2].CompanyID)
+	})
+
+	t.Run("unparsable date row skipped and valid rows still resolve without error", func(t *testing.T) {
+		rows := []DBModel{
+			parent("id-bad", "Acme", "not-a-date"),
+			parent("id-2", "Acme", "2021-01-01T00:00:00Z"),
+			parent("id-1", "Acme", "2019-01-01T00:00:00Z"),
+		}
+		result, err := dbModelsToResponseModels(ctx, rows, false)
+		require.NoError(t, err, "conversion error on a skipped row must not poison a usable result")
+		require.Len(t, result, 1)
+		assert.Equal(t, "id-1", result[0].CompanyID)
+	})
+
+	t.Run("all rows fail conversion returns error and empty list", func(t *testing.T) {
+		rows := []DBModel{
+			parent("id-1", "Acme", "not-a-date"),
+			parent("id-2", "Acme", "also-not-a-date"),
+		}
+		result, err := dbModelsToResponseModels(ctx, rows, false)
+		assert.Error(t, err)
+		assert.Empty(t, result)
+	})
+}

--- a/cla-backend-go/events/event_data.go
+++ b/cla-backend-go/events/event_data.go
@@ -550,7 +550,7 @@ func (ed *SignatureAutoCreateECLAUpdatedEventData) GetEventDetailsString(args *L
 		data = data + fmt.Sprintf(" for the project %s", args.ProjectName)
 	}
 	if args.ProjectSFID != "" {
-		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectName)
+		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectSFID)
 	}
 	if args.CompanyName != "" {
 		data = data + fmt.Sprintf(" for the company %s", args.CompanyName)
@@ -916,7 +916,7 @@ func (ed *GitLabOrganizationUpdatedEventData) GetEventDetailsString(args *LogEve
 		data = fmt.Sprintf("%s for the project %s", data, args.ProjectName)
 	}
 	if args.ProjectSFID != "" {
-		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectName)
+		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectSFID)
 	}
 	if args.UserName != "" {
 		data = fmt.Sprintf("%s by the user %s", data, args.UserName)
@@ -986,7 +986,7 @@ func (ed *CLAManagerDeletedEventData) GetEventDetailsString(args *LogEventArgs) 
 		data = data + fmt.Sprintf(" for the project %s", args.ProjectName)
 	}
 	if args.ProjectSFID != "" {
-		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectName)
+		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectSFID)
 	}
 	if args.CompanyName != "" {
 		data = data + fmt.Sprintf(" for the company %s", args.CompanyName)
@@ -1041,7 +1041,7 @@ func (ed *CLAApprovalListAddEmailData) GetEventDetailsString(args *LogEventArgs)
 		data = data + fmt.Sprintf(" for the project %s", args.ProjectName)
 	}
 	if args.ProjectSFID != "" {
-		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectName)
+		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectSFID)
 	}
 	if args.CompanyName != "" {
 		data = data + fmt.Sprintf(" for the company %s", args.CompanyName)
@@ -1063,7 +1063,7 @@ func (ed *CLAApprovalListRemoveEmailData) GetEventDetailsString(args *LogEventAr
 		data = data + fmt.Sprintf(" for the project %s", args.ProjectName)
 	}
 	if args.ProjectSFID != "" {
-		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectName)
+		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectSFID)
 	}
 	if args.CompanyName != "" {
 		data = data + fmt.Sprintf(" for the company %s", args.CompanyName)
@@ -1085,7 +1085,7 @@ func (ed *CLAApprovalListAddDomainData) GetEventDetailsString(args *LogEventArgs
 		data = data + fmt.Sprintf(" for the project %s", args.ProjectName)
 	}
 	if args.ProjectSFID != "" {
-		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectName)
+		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectSFID)
 	}
 	if args.CompanyName != "" {
 		data = data + fmt.Sprintf(" for the company %s", args.CompanyName)
@@ -1107,7 +1107,7 @@ func (ed *CLAApprovalListRemoveDomainData) GetEventDetailsString(args *LogEventA
 		data = data + fmt.Sprintf(" for the project %s", args.ProjectName)
 	}
 	if args.ProjectSFID != "" {
-		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectName)
+		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectSFID)
 	}
 	if args.CompanyName != "" {
 		data = data + fmt.Sprintf(" for the company %s", args.CompanyName)
@@ -1129,7 +1129,7 @@ func (ed *CLAApprovalListAddGitHubUsernameData) GetEventDetailsString(args *LogE
 		data = data + fmt.Sprintf(" for the project %s", args.ProjectName)
 	}
 	if args.ProjectSFID != "" {
-		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectName)
+		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectSFID)
 	}
 	if args.CompanyName != "" {
 		data = data + fmt.Sprintf(" for the company %s", args.CompanyName)
@@ -1151,7 +1151,7 @@ func (ed *CLAApprovalListRemoveGitHubUsernameData) GetEventDetailsString(args *L
 		data = data + fmt.Sprintf(" for the project %s", args.ProjectName)
 	}
 	if args.ProjectSFID != "" {
-		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectName)
+		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectSFID)
 	}
 	if args.CompanyName != "" {
 		data = data + fmt.Sprintf(" for the company %s", args.CompanyName)
@@ -1173,7 +1173,7 @@ func (ed *CLAApprovalListAddGitHubOrgData) GetEventDetailsString(args *LogEventA
 		data = data + fmt.Sprintf(" for the project %s", args.ProjectName)
 	}
 	if args.ProjectSFID != "" {
-		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectName)
+		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectSFID)
 	}
 	if args.CompanyName != "" {
 		data = data + fmt.Sprintf(" for the company %s", args.CompanyName)
@@ -1195,7 +1195,7 @@ func (ed *CLAApprovalListRemoveGitHubOrgData) GetEventDetailsString(args *LogEve
 		data = data + fmt.Sprintf(" for the project %s", args.ProjectName)
 	}
 	if args.ProjectSFID != "" {
-		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectName)
+		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectSFID)
 	}
 	if args.CompanyName != "" {
 		data = data + fmt.Sprintf(" for the company %s", args.CompanyName)
@@ -1217,7 +1217,7 @@ func (ed *CLAApprovalListAddGitLabUsernameData) GetEventDetailsString(args *LogE
 		data = data + fmt.Sprintf(" for the project %s", args.ProjectName)
 	}
 	if args.ProjectSFID != "" {
-		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectName)
+		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectSFID)
 	}
 	if args.CompanyName != "" {
 		data = data + fmt.Sprintf(" for the company %s", args.CompanyName)
@@ -1239,7 +1239,7 @@ func (ed *CLAApprovalListRemoveGitLabUsernameData) GetEventDetailsString(args *L
 		data = data + fmt.Sprintf(" for the project %s", args.ProjectName)
 	}
 	if args.ProjectSFID != "" {
-		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectName)
+		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectSFID)
 	}
 	if args.CompanyName != "" {
 		data = data + fmt.Sprintf(" for the company %s", args.CompanyName)
@@ -1261,7 +1261,7 @@ func (ed *CLAApprovalListAddGitLabGroupData) GetEventDetailsString(args *LogEven
 		data = data + fmt.Sprintf(" for the project %s", args.ProjectName)
 	}
 	if args.ProjectSFID != "" {
-		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectName)
+		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectSFID)
 	}
 	if args.CompanyName != "" {
 		data = data + fmt.Sprintf(" for the company %s", args.CompanyName)
@@ -1283,7 +1283,7 @@ func (ed *CLAApprovalListRemoveGitLabGroupData) GetEventDetailsString(args *LogE
 		data = data + fmt.Sprintf(" for the project %s", args.ProjectName)
 	}
 	if args.ProjectSFID != "" {
-		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectName)
+		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectSFID)
 	}
 	if args.CompanyName != "" {
 		data = data + fmt.Sprintf(" for the company %s", args.CompanyName)
@@ -1589,7 +1589,7 @@ func (ed *AssignRoleScopeData) GetEventDetailsString(args *LogEventArgs) (string
 		data = data + fmt.Sprintf(" for the project %s", args.ProjectName)
 	}
 	if args.ProjectSFID != "" {
-		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectName)
+		data = data + fmt.Sprintf(" with project SFID %s", args.ProjectSFID)
 	}
 	if args.CompanyName != "" {
 		data = data + fmt.Sprintf(" for the company %s", args.CompanyName)

--- a/cla-backend-go/events/event_data_test.go
+++ b/cla-backend-go/events/event_data_test.go
@@ -193,6 +193,41 @@ func TestSignatureProjectInvalidatedEventDataSingleSignature(t *testing.T) {
 	assert.Equal(t, "The signature sig-2 was invalidated (approved set to false).", details)
 }
 
+func TestEventDetailsStringUsesProjectSFID(t *testing.T) {
+	// covers the 16 formatters that printed args.ProjectName after the "with project SFID" label
+	args := &LogEventArgs{UserName: testUser, ProjectName: "Sample Project", ProjectSFID: "proj-sfid-123"}
+
+	testCases := []struct {
+		name      string
+		eventData EventData
+	}{
+		{name: "SignatureAutoCreateECLAUpdated", eventData: &SignatureAutoCreateECLAUpdatedEventData{}},
+		{name: "GitLabOrganizationUpdated", eventData: &GitLabOrganizationUpdatedEventData{}},
+		{name: "CLAManagerDeleted", eventData: &CLAManagerDeletedEventData{}},
+		{name: "CLAApprovalListAddEmail", eventData: &CLAApprovalListAddEmailData{}},
+		{name: "CLAApprovalListRemoveEmail", eventData: &CLAApprovalListRemoveEmailData{}},
+		{name: "CLAApprovalListAddDomain", eventData: &CLAApprovalListAddDomainData{}},
+		{name: "CLAApprovalListRemoveDomain", eventData: &CLAApprovalListRemoveDomainData{}},
+		{name: "CLAApprovalListAddGitHubUsername", eventData: &CLAApprovalListAddGitHubUsernameData{}},
+		{name: "CLAApprovalListRemoveGitHubUsername", eventData: &CLAApprovalListRemoveGitHubUsernameData{}},
+		{name: "CLAApprovalListAddGitHubOrg", eventData: &CLAApprovalListAddGitHubOrgData{}},
+		{name: "CLAApprovalListRemoveGitHubOrg", eventData: &CLAApprovalListRemoveGitHubOrgData{}},
+		{name: "CLAApprovalListAddGitLabUsername", eventData: &CLAApprovalListAddGitLabUsernameData{}},
+		{name: "CLAApprovalListRemoveGitLabUsername", eventData: &CLAApprovalListRemoveGitLabUsernameData{}},
+		{name: "CLAApprovalListAddGitLabGroup", eventData: &CLAApprovalListAddGitLabGroupData{}},
+		{name: "CLAApprovalListRemoveGitLabGroup", eventData: &CLAApprovalListRemoveGitLabGroupData{}},
+		{name: "AssignRoleScope", eventData: &AssignRoleScopeData{}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(tt *testing.T) {
+			details, _ := tc.eventData.GetEventDetailsString(args)
+			assert.Contains(tt, details, " with project SFID proj-sfid-123")
+			assert.NotContains(tt, details, "with project SFID Sample Project")
+		})
+	}
+}
+
 func TestCompanySanctionedEventData(t *testing.T) {
 	eventData := &CompanySanctionedEventData{}
 	args := &LogEventArgs{CompanyName: "Flagged Corp"}

--- a/cla-backend-go/projects_cla_groups/repository.go
+++ b/cla-backend-go/projects_cla_groups/repository.go
@@ -174,7 +174,7 @@ func (repo *repo) GetClaGroupIDForProject(ctx context.Context, projectSFID strin
 		pcgs, foundationErr := repo.GetProjectsIdsForFoundation(ctx, projectSFID)
 		if foundationErr != nil {
 			log.WithFields(f).Warnf("unable to lookup CLA Group associated with project, error: %+v", foundationErr)
-			return nil, err
+			return nil, foundationErr
 		}
 
 		if len(pcgs) == 0 {

--- a/cla-backend-go/signatures/repository.go
+++ b/cla-backend-go/signatures/repository.go
@@ -5259,6 +5259,7 @@ func (repo repository) GetClaGroupCorporateContributors(ctx context.Context, cla
 			out.List = append(out.List, &models.CorporateContributor{
 				SignatureID:            sig.SignatureID,
 				GithubID:               sig.UserGithubUsername,
+				GitlabID:               sig.UserGitlabUsername,
 				LinuxFoundationID:      sig.UserLFUsername,
 				Name:                   sigName,
 				SignatureVersion:       signatureVersion,

--- a/cla-backend-go/swagger/cla.v2.yaml
+++ b/cla-backend-go/swagger/cla.v2.yaml
@@ -5411,7 +5411,7 @@ parameters:
     required: true
   myClasLfUsername:
     name: lfUsername
-    description: The LF username (LFID) of the user - when omitted, the authenticated principal's username is used; unless the caller is an admin or a trusted LFX Self Serve client, a different value is not searched and is reported in skippedIdentities. The caller-supplied identity list is transitional - at M6, once EasyCLA runs on the K8s cluster, it should call lfx.auth-service.user_identity.list over NATS itself and drop both the list and the azp allow-list authorizing it
+    description: The LF username (LFID) of the user - when omitted, the authenticated principal's username is used; unless the caller is an admin or a trusted LFX Self Serve client, a different value is not searched and is reported in skippedIdentities. The caller-supplied identity list is transitional - at M5, once EasyCLA runs on the K8s cluster, it should call lfx.auth-service.user_identity.list over NATS itself and drop both the list and the azp allow-list authorizing it
     in: query
     type: string
     required: false

--- a/cla-backend-go/swagger/common/corporate-contributor.yaml
+++ b/cla-backend-go/swagger/common/corporate-contributor.yaml
@@ -19,6 +19,10 @@ properties:
     type: string
     example: "123456"
     x-omitempty: false
+  gitlab_id:
+    type: string
+    example: "789012"
+    x-omitempty: false
   email:
     type: string
     example: "v1"

--- a/cla-backend-go/swagger/common/corporate-contributor.yaml
+++ b/cla-backend-go/swagger/common/corporate-contributor.yaml
@@ -17,11 +17,13 @@ properties:
     x-omitempty: false
   github_id:
     type: string
+    description: the contributor's GitHub username (login)
     example: "123456"
     x-omitempty: false
   gitlab_id:
     type: string
-    example: "789012"
+    description: the contributor's GitLab username (login), mirroring github_id
+    example: "jdoe"
     x-omitempty: false
   email:
     type: string

--- a/cla-backend-go/v2/cla_manager/handlers.go
+++ b/cla-backend-go/v2/cla_manager/handlers.go
@@ -49,7 +49,7 @@ func Configure(api *operations.EasyclaAPI, service Service, v1CompanyService v1C
 			utils.XREQUESTID: ctx.Value(utils.XREQUESTID),
 			"CompanyID":      params.CompanyID,
 			"ProjectSFID":    params.ProjectSFID,
-			"authUser":       *params.XUSERNAME,
+			"authUser":       utils.StringValue(params.XUSERNAME),
 		}
 
 		// Lookup the company by internal ID
@@ -101,7 +101,7 @@ func Configure(api *operations.EasyclaAPI, service Service, v1CompanyService v1C
 			"CompanyID":      params.CompanyID,
 			"ProjectSFID":    params.ProjectSFID,
 			"userLFID":       params.UserLFID,
-			"authUser":       *params.XUSERNAME,
+			"authUser":       utils.StringValue(params.XUSERNAME),
 		}
 
 		// Lookup the company by internal ID
@@ -144,7 +144,7 @@ func Configure(api *operations.EasyclaAPI, service Service, v1CompanyService v1C
 			utils.XREQUESTID: ctx.Value(utils.XREQUESTID),
 			"CompanyID":      params.CompanyID,
 			"ProjectSFID":    params.ProjectSFID,
-			"authUser":       *params.XUSERNAME,
+			"authUser":       utils.StringValue(params.XUSERNAME),
 		}
 
 		// Lookup the company by internal ID

--- a/cla-backend-go/v2/company/service.go
+++ b/cla-backend-go/v2/company/service.go
@@ -1684,6 +1684,7 @@ func fillCorporateContributorModel(wg *sync.WaitGroup, usersRepo users.UserRepos
 	var contributor models.CorporateContributor
 	var sigSignedTime = sig.SignatureCreated
 	contributor.GithubID = user.GithubUsername
+	contributor.GitlabID = user.GitlabUsername
 	contributor.LinuxFoundationID = user.LfUsername
 	contributor.SignatureApproved = sig.SignatureApproved
 	contributor.SignatureSigned = sig.SignatureSigned

--- a/cla-backend-go/v2/company/service_test.go
+++ b/cla-backend-go/v2/company/service_test.go
@@ -167,6 +167,7 @@ func TestGetCompanyProjectContributors(t *testing.T) {
 				mockUserRepo.EXPECT().GetUser(sig.SignatureReferenceID).Return(&v1Models.User{
 					Username:       "username",
 					GithubUsername: "github-username",
+					GitlabUsername: "gitlab-username",
 					LfUsername:     "lf-username",
 					UserID:         sig.SignatureReferenceID,
 				}, nil)
@@ -190,6 +191,7 @@ func TestGetCompanyProjectContributors(t *testing.T) {
 			// check the timestamp order
 			for i, expected := range tc.expectedOrder {
 				assert.Equal(t, expected, response.List[i].Timestamp)
+				assert.Equal(t, "gitlab-username", response.List[i].GitlabID)
 			}
 		})
 	}

--- a/cla-backend-go/v2/dynamo_events/signatures.go
+++ b/cla-backend-go/v2/dynamo_events/signatures.go
@@ -292,6 +292,12 @@ func (s *service) SignatureAddSigTypeSignedApprovedID(event events.DynamoDBEvent
 		if err != nil {
 			return err
 		}
+	case newSig.SignatureType == ECLASignatureType && newSig.SignatureUserCompanyID != "":
+		// auto-created employee acknowledgement (approval-list auto_create_ecla flow -
+		// signatures/repository.go CreateProjectCompanyEmployeeSignature); same GSI value
+		// shape as the DocuSign employee-ecla case above (ecla#signed#approved#companyID)
+		sigType = ECLASignatureType
+		id = newSig.SignatureUserCompanyID
 	default:
 		log.WithFields(f).Warnf("setting sigtype_signed_approved_id for signature: %s failed", newSig.SignatureID)
 		return errors.New("invalid signature in SignatureAddSigTypeSignedApprovedID")

--- a/cla-backend-go/v2/dynamo_events/signatures_test.go
+++ b/cla-backend-go/v2/dynamo_events/signatures_test.go
@@ -1,0 +1,138 @@
+// Copyright The Linux Foundation and each contributor to CommunityBridge.
+// SPDX-License-Identifier: MIT
+
+package dynamo_events
+
+import (
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	mock_company "github.com/linuxfoundation/easycla/cla-backend-go/company/mocks"
+	"github.com/linuxfoundation/easycla/cla-backend-go/gen/v1/models"
+	"github.com/linuxfoundation/easycla/cla-backend-go/projects_cla_groups"
+	mock_pcg_repo "github.com/linuxfoundation/easycla/cla-backend-go/projects_cla_groups/mocks"
+	mock_signatures "github.com/linuxfoundation/easycla/cla-backend-go/signatures/mocks"
+)
+
+func TestSignatureAddSigTypeSignedApprovedID(t *testing.T) {
+	tests := []struct {
+		name          string
+		newImage      map[string]events.DynamoDBAttributeValue
+		setup         func(sigRepo *mock_signatures.MockSignatureRepository, companyRepo *mock_company.MockIRepository, pcgRepo *mock_pcg_repo.MockRepository)
+		wantErrSubstr string
+	}{
+		{
+			name: "ccla unchanged",
+			newImage: map[string]events.DynamoDBAttributeValue{
+				"signature_id":           events.NewStringAttribute("sig-ccla"),
+				"signature_type":         events.NewStringAttribute("ccla"),
+				"signature_reference_id": events.NewStringAttribute("company-1"),
+				"signature_signed":       events.NewBooleanAttribute(true),
+				"signature_approved":     events.NewBooleanAttribute(true),
+			},
+			setup: func(sigRepo *mock_signatures.MockSignatureRepository, _ *mock_company.MockIRepository, _ *mock_pcg_repo.MockRepository) {
+				sigRepo.EXPECT().AddSigTypeSignedApprovedID(gomock.Any(), "sig-ccla", "ccla#true#true#company-1").Return(nil)
+			},
+		},
+		{
+			name: "icla unchanged",
+			newImage: map[string]events.DynamoDBAttributeValue{
+				"signature_id":           events.NewStringAttribute("sig-icla"),
+				"signature_type":         events.NewStringAttribute("cla"),
+				"signature_reference_id": events.NewStringAttribute("user-1"),
+				"signature_signed":       events.NewBooleanAttribute(true),
+				"signature_approved":     events.NewBooleanAttribute(true),
+			},
+			setup: func(sigRepo *mock_signatures.MockSignatureRepository, _ *mock_company.MockIRepository, _ *mock_pcg_repo.MockRepository) {
+				sigRepo.EXPECT().AddSigTypeSignedApprovedID(gomock.Any(), "sig-icla", "icla#true#true#user-1").Return(nil)
+			},
+		},
+		{
+			name: "docusign employee ecla unchanged",
+			newImage: map[string]events.DynamoDBAttributeValue{
+				"signature_id":                   events.NewStringAttribute("sig-docusign-ecla"),
+				"signature_type":                 events.NewStringAttribute("cla"),
+				"signature_reference_id":         events.NewStringAttribute("user-1"),
+				"signature_user_ccla_company_id": events.NewStringAttribute("company-1"),
+				"signature_project_id":           events.NewStringAttribute("cla-group-1"),
+				"signature_signed":               events.NewBooleanAttribute(true),
+				"signature_approved":             events.NewBooleanAttribute(true),
+			},
+			setup: func(sigRepo *mock_signatures.MockSignatureRepository, companyRepo *mock_company.MockIRepository, pcgRepo *mock_pcg_repo.MockRepository) {
+				// assignContributor short-circuits: company found, but no SF projects for the CLA group
+				companyRepo.EXPECT().GetCompany(gomock.Any(), "company-1").
+					Return(&models.Company{CompanyID: "company-1", CompanyExternalID: "ext-sfid-1"}, nil)
+				pcgRepo.EXPECT().GetProjectsIdsForClaGroup(gomock.Any(), "cla-group-1").
+					Return([]*projects_cla_groups.ProjectClaGroup{}, nil)
+				sigRepo.EXPECT().AddSigTypeSignedApprovedID(gomock.Any(), "sig-docusign-ecla", "ecla#true#true#company-1").Return(nil)
+			},
+		},
+		{
+			name: "auto-created literal ecla populates the GSI key",
+			newImage: map[string]events.DynamoDBAttributeValue{
+				"signature_id":                   events.NewStringAttribute("sig-auto-ecla"),
+				"signature_type":                 events.NewStringAttribute("ecla"),
+				"signature_reference_id":         events.NewStringAttribute("user-1"),
+				"signature_user_ccla_company_id": events.NewStringAttribute("company-1"),
+				"signature_signed":               events.NewBooleanAttribute(true),
+				"signature_approved":             events.NewBooleanAttribute(true),
+			},
+			setup: func(sigRepo *mock_signatures.MockSignatureRepository, _ *mock_company.MockIRepository, _ *mock_pcg_repo.MockRepository) {
+				sigRepo.EXPECT().AddSigTypeSignedApprovedID(gomock.Any(), "sig-auto-ecla", "ecla#true#true#company-1").Return(nil)
+			},
+		},
+		{
+			name: "literal ecla without company id still errors",
+			newImage: map[string]events.DynamoDBAttributeValue{
+				"signature_id":       events.NewStringAttribute("sig-bad-ecla"),
+				"signature_type":     events.NewStringAttribute("ecla"),
+				"signature_signed":   events.NewBooleanAttribute(true),
+				"signature_approved": events.NewBooleanAttribute(true),
+			},
+			wantErrSubstr: "invalid signature",
+		},
+		{
+			name: "invalid signature type errors",
+			newImage: map[string]events.DynamoDBAttributeValue{
+				"signature_id":       events.NewStringAttribute("sig-bad"),
+				"signature_type":     events.NewStringAttribute("bogus"),
+				"signature_signed":   events.NewBooleanAttribute(true),
+				"signature_approved": events.NewBooleanAttribute(true),
+			},
+			wantErrSubstr: "invalid signature",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			sigRepo := mock_signatures.NewMockSignatureRepository(ctrl)
+			companyRepo := mock_company.NewMockIRepository(ctrl)
+			pcgRepo := mock_pcg_repo.NewMockRepository(ctrl)
+			if tc.setup != nil {
+				tc.setup(sigRepo, companyRepo, pcgRepo)
+			}
+
+			s := &service{
+				signatureRepo:        sigRepo,
+				companyRepo:          companyRepo,
+				projectsClaGroupRepo: pcgRepo,
+			}
+
+			err := s.SignatureAddSigTypeSignedApprovedID(events.DynamoDBEventRecord{
+				Change: events.DynamoDBStreamRecord{NewImage: tc.newImage},
+			})
+
+			if tc.wantErrSubstr != "" {
+				assert.ErrorContains(t, err, tc.wantErrSubstr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/cla-backend-go/v2/signatures/corporate_contributors_test.go
+++ b/cla-backend-go/v2/signatures/corporate_contributors_test.go
@@ -24,6 +24,7 @@ func corporateContributorsFixture() *v1Models.CorporateContributorList {
 				SignatureID:       "sig-1",
 				SignatureVersion:  "2",
 				GithubID:          "gh-alice",
+				GitlabID:          "gl-alice",
 				LinuxFoundationID: "alice-lfid",
 				Name:              "Alice Smith",
 				Email:             "alice@example.com",
@@ -122,6 +123,7 @@ func TestService_GetClaGroupCorporateContributors(t *testing.T) {
 	assert.Equal(t, "2", result.List[0].SignatureVersion, "signature_version must survive the v1 to v2 conversion")
 	assert.Equal(t, "alice-lfid", result.List[0].LinuxFoundationID)
 	assert.Equal(t, "gh-alice", result.List[0].GithubID)
+	assert.Equal(t, "gl-alice", result.List[0].GitlabID, "gitlab_id must survive the v1 to v2 conversion")
 	assert.Equal(t, "sig-2", result.List[1].SignatureID)
 	assert.Empty(t, result.List[1].LinuxFoundationID, "a contributor without an LF login must not be dropped")
 	assert.Equal(t, "bob@example.com", result.List[1].Email)

--- a/cla-backend-go/v2/signatures/ecla_invalidate_test.go
+++ b/cla-backend-go/v2/signatures/ecla_invalidate_test.go
@@ -220,6 +220,41 @@ func TestService_InvalidateECLAValidation(t *testing.T) {
 		{name: "already invalidated ecla conflicts", sig: invalidated, authUser: managerUser, expectedErr: errEclaAlreadyInvalidated},
 	}
 
+	// the panic-after-write regression lock: GetCLAGroupByID returning (nil, nil) must error
+	// out BEFORE the signature is invalidated
+	t.Run("cla group lookup returning nil without error is rejected before any mutation", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		ctx := context.Background()
+
+		mockRepo := mock_v1_signatures.NewMockSignatureRepository(ctrl)
+		mockRepo.EXPECT().GetItemSignature(ctx, "sig-1").Return(eclaItemSignature(), nil)
+		mockRepo.EXPECT().InvalidateProjectRecordWithMetadata(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+		mockCompanyService := mock_company.NewMockIService(ctrl)
+		mockCompanyService.EXPECT().GetCompany(ctx, "company-1").
+			Return(&v1Models.Company{CompanyID: "company-1", CompanyExternalID: "comp-sfid", CompanyName: "Acme"}, nil)
+
+		mockProjectClaGroupsRepo := mock_projects_cla_groups.NewMockRepository(ctrl)
+		mockProjectClaGroupsRepo.EXPECT().GetProjectsIdsForClaGroup(ctx, "cla-group-1").
+			Return([]*projects_cla_groups.ProjectClaGroup{{ProjectSFID: "proj-sfid"}}, nil)
+
+		mockUserService := mock_users.NewMockService(ctrl)
+		mockUserService.EXPECT().GetUser("user-1").
+			Return(&v1Models.User{UserID: "user-1", LfUsername: "contributor"}, nil)
+
+		mockProjectService := mock_project.NewMockService(ctrl)
+		mockProjectService.EXPECT().GetCLAGroupByID(ctx, "cla-group-1").Return(nil, nil)
+
+		service := NewService(awsSession, "", mockProjectService, mockCompanyService, nil, mockProjectClaGroupsRepo, mockRepo, mockUserService, nil)
+
+		result, err := service.InvalidateECLA(ctx, "cla-group-1", "sig-1", managerUser, nil, eclaEventArgs(), nil)
+		assert.Nil(t, result)
+		if assert.Error(t, err) {
+			assert.Contains(t, err.Error(), "cla group not found for claGroupID: cla-group-1")
+		}
+	})
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)

--- a/cla-backend-go/v2/signatures/service.go
+++ b/cla-backend-go/v2/signatures/service.go
@@ -514,6 +514,9 @@ func (s *Service) InvalidateECLA(ctx context.Context, claGroupID string, signatu
 	if claGrpErr != nil {
 		return nil, claGrpErr
 	}
+	if claGroup == nil {
+		return nil, fmt.Errorf("cla group not found for claGroupID: %s", claGroupID)
+	}
 
 	log.WithFields(f).Debug("invalidating signature record ...")
 	note := fmt.Sprintf("Signature invalidated (approved set to false) by %s for %s ", authUser.UserName, utils.GetBestUsername(user))

--- a/cla-backend-legacy/internal/api/handlers.go
+++ b/cla-backend-legacy/internal/api/handlers.go
@@ -5098,7 +5098,7 @@ func (h *Handlers) GetUnsignedProjectsForCompanyV1(w http.ResponseWriter, r *htt
 // caller gets an explicit, permanent signal instead of a generic 404/405.
 func (h *Handlers) PostCompanyV1(w http.ResponseWriter, r *http.Request) {
 	respond.JSON(w, http.StatusGone, respond.ErrorBody{
-		Message: "This endpoint has been retired and no longer creates companies. Create companies through the EasyCLA v2 API.",
+		Message: "This endpoint has been retired and no longer creates companies. Use the EasyCLA v2 API instead: POST /v4/user/{userID}/company (createCompany).",
 	})
 }
 

--- a/cla-backend-legacy/internal/api/handlers.go
+++ b/cla-backend-legacy/internal/api/handlers.go
@@ -5091,111 +5091,15 @@ func (h *Handlers) GetUnsignedProjectsForCompanyV1(w http.ResponseWriter, r *htt
 	respond.JSON(w, http.StatusOK, unsigned)
 }
 
-// POST /v1/company
-// Python: cla/routes.py:1189 post_company()
-// Calls: cla.controllers.company.create_company
-
+// POST /v1/company — retired (#2055): this path persisted companies without
+// company_external_id, producing orphans that never sync to Salesforce/org-service.
+// Company creation is v2-only now (v2/company.Service.CreateCompany -> orgClient.CreateOrg,
+// which always sets the external id). Kept registered (not unregistered) so every
+// caller gets an explicit, permanent signal instead of a generic 404/405.
 func (h *Handlers) PostCompanyV1(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-
-	authUser, authErrResp, err := h.authValidator.Authenticate(r.Header)
-	if err != nil {
-		respond.JSON(w, http.StatusUnauthorized, authErrResp)
-		return
-	}
-
-	type request struct {
-		CompanyName string `json:"company_name"`
-		// CompanyManagerUserName, CompanyManagerUserEmail, CompanyManagerID are parsed for
-		// API compatibility but not used in company creation (mirrors Python behavior)
-		IsSanctioned *bool `json:"is_sanctioned"`
-	}
-	var req request
-	body, err := parseFlexibleParams(r)
-	if err != nil {
-		respond.JSON(w, http.StatusBadRequest, map[string]any{"errors": map[string]any{"body": "invalid json"}})
-		return
-	}
-	if v, ok := flexibleStringParam(r, body, "company_name"); ok {
-		req.CompanyName = v
-	}
-	// Note: company_manager_* fields are parsed for API compatibility but not used in company creation
-	// This mirrors the Python behavior where these fields exist in the API but are not stored
-	if b, ok, err := flexibleBoolParam(r, body, "is_sanctioned"); err != nil {
-		respond.JSON(w, http.StatusBadRequest, map[string]any{"errors": map[string]any{"is_sanctioned": err.Error()}})
-		return
-	} else if ok {
-		req.IsSanctioned = &b
-	}
-	companyName := strings.TrimSpace(req.CompanyName)
-	if companyName == "" {
-		respond.JSON(w, http.StatusBadRequest, map[string]any{"errors": map[string]any{"company_name": "Missing required value"}})
-		return
-	}
-
-	isSanctioned := false
-	if req.IsSanctioned != nil {
-		isSanctioned = *req.IsSanctioned
-	}
-
-	// Manager is always the authenticated user in the legacy Python controller.
-	managerItem, _, err := h.getOrCreateUser(ctx, authUser)
-	if err != nil {
-		respond.JSON(w, http.StatusInternalServerError, map[string]any{"errors": map[string]any{"server": err.Error()}})
-		return
-	}
-	managerID := getAttrString(managerItem, "user_id")
-
-	// Duplicate check matches Python: iterate all companies and compare company_name exactly.
-	companies, err := h.companies.ScanAll(ctx)
-	if err != nil {
-		respond.JSON(w, http.StatusInternalServerError, map[string]any{"errors": map[string]any{"server": err.Error()}})
-		return
-	}
-	for _, c := range companies {
-		if getAttrString(c, "company_name") == companyName {
-			respond.JSON(w, http.StatusConflict, map[string]any{
-				"error":      "Company already exists.",
-				"company_id": getAttrString(c, "company_id"),
-			})
-			return
-		}
-	}
-
-	now := time.Now().UTC()
-	companyID := uuid.New().String()
-	item := map[string]types.AttributeValue{
-		"company_id":          &types.AttributeValueMemberS{Value: companyID},
-		"company_name":        &types.AttributeValueMemberS{Value: companyName},
-		"signing_entity_name": &types.AttributeValueMemberS{Value: companyName},
-		"company_manager_id":  &types.AttributeValueMemberS{Value: managerID},
-		"company_acl":         &types.AttributeValueMemberSS{Value: []string{authUser.Username}},
-		"is_sanctioned":       &types.AttributeValueMemberBOOL{Value: isSanctioned},
-		"date_created":        &types.AttributeValueMemberS{Value: formatPynamoDateTimeUTC(now)},
-		"date_modified":       &types.AttributeValueMemberS{Value: formatPynamoDateTimeUTC(now)},
-		"version":             &types.AttributeValueMemberS{Value: "v1"},
-	}
-	if isSanctioned {
-		item["sanctioned_date"] = &types.AttributeValueMemberS{Value: formatPynamoDateTimeUTC(now)}
-	}
-
-	if err := h.companies.PutItem(ctx, item); err != nil {
-		respond.JSON(w, http.StatusInternalServerError, map[string]any{"errors": map[string]any{"server": err.Error()}})
-		return
-	}
-
-	// Audit event (best-effort), matches controller wording.
-	eventData := fmt.Sprintf("User %s created company %s with company_id: %s.", authUser.Username, companyName, companyID)
-	eventSummary := fmt.Sprintf("User %s created company %s.", authUser.Username, companyName)
-	h.putAuditEventBestEffort(ctx, auditEventInput{
-		EventType:      "CreateCompany",
-		EventCompanyID: companyID,
-		EventData:      eventData,
-		EventSummary:   eventSummary,
-		ContainsPII:    false,
+	respond.JSON(w, http.StatusGone, respond.ErrorBody{
+		Message: "This endpoint has been retired and no longer creates companies. Create companies through the EasyCLA v2 API.",
 	})
-
-	respond.JSON(w, http.StatusOK, store.ItemToInterfaceMap(item))
 }
 
 // PUT /v1/company

--- a/cla-backend-legacy/internal/api/handlers_company_test.go
+++ b/cla-backend-legacy/internal/api/handlers_company_test.go
@@ -1,0 +1,48 @@
+// Copyright The Linux Foundation and each contributor to CommunityBridge.
+// SPDX-License-Identifier: MIT
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestPostCompanyV1_Retired locks in the #2055 fix: legacy company creation
+// is permanently gone, unconditionally, so no caller can persist a company
+// row without company_external_id through POST /v1/company.
+func TestPostCompanyV1_Retired(t *testing.T) {
+	h := &Handlers{} // zero-value: no store/auth deps needed post-retirement
+	req := httptest.NewRequest(http.MethodPost, "/v1/company", strings.NewReader(`{"company_name":"Acme"}`))
+	rec := httptest.NewRecorder()
+
+	h.PostCompanyV1(rec, req)
+
+	if rec.Code != http.StatusGone {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusGone)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("invalid JSON body: %v", err)
+	}
+	if _, ok := body["message"]; !ok {
+		t.Fatalf("body missing message key: %v", body)
+	}
+}
+
+// TestPostCompanyV1_RetiredIgnoresAuth asserts the 410 is unconditional —
+// no Authorization header, no body — so behavior can't vary by auth state.
+func TestPostCompanyV1_RetiredIgnoresAuth(t *testing.T) {
+	h := &Handlers{}
+	req := httptest.NewRequest(http.MethodPost, "/v1/company", nil)
+	rec := httptest.NewRecorder()
+
+	h.PostCompanyV1(rec, req)
+
+	if rec.Code != http.StatusGone {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusGone)
+	}
+}

--- a/tests/functional/cypress/e2e/v1/company.cy.ts
+++ b/tests/functional/cypress/e2e/v1/company.cy.ts
@@ -153,11 +153,11 @@ describe('To Validate & test Company APIs via API call (V1)', function () {
           headers: { Authorization: `Bearer ${bearerToken}` },
         },
         {
-          title: 'POST /company (method not allowed) - returns 401 unauthorized',
+          title: 'POST /company (retired) - returns 410 gone',
           method: 'POST',
           url: `${claEndpoint}company`,
           body: {},
-          expectedStatus: 401, // V1 API returns 401 for unauthorized POST requests
+          expectedStatus: 410, // was 401 — endpoint retired per #2055, now unconditional
         },
         {
           title: 'PUT /company (method not allowed)',

--- a/utils/audit_company_reachability.sh
+++ b/utils/audit_company_reachability.sh
@@ -68,7 +68,7 @@ classify () {
     return
   fi
   local code
-  code="$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer ${TOKEN}" "${GW}/organization-service/v1/orgs/${sfid}")"
+  code="$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 20 -H "Authorization: Bearer ${TOKEN}" "${GW}/organization-service/v1/orgs/${sfid}")"
   [ -n "$SLEEP_S" ] && sleep "$SLEEP_S"
   case "$code" in
     200) echo "SFID_OK" ;;
@@ -77,7 +77,7 @@ classify () {
   esac
 }
 
-echo -e "company_id\tcompany_name\tsigning_entity_name\tcompany_external_id\tsfid_status\tactive_ccla_count\tactive_ecla_count"
+printf 'company_id\tcompany_name\tsigning_entity_name\tcompany_external_id\tsfid_status\tactive_ccla_count\tactive_ecla_count\n'
 
 total=0
 missing=0
@@ -104,6 +104,9 @@ do
     company_name="$(echo "$item" | jq -r '.company_name.S // ""')"
     signing_entity_name="$(echo "$item" | jq -r '.signing_entity_name.S // ""')"
     sfid="$(echo "$item" | jq -r '.company_external_id.S // ""')"
+    # trim so a whitespace-only SFID is tiered MISSING_SFID (authoritative), not queried
+    sfid="${sfid#"${sfid%%[![:space:]]*}"}"
+    sfid="${sfid%"${sfid##*[![:space:]]}"}"
 
     status="$(classify "$sfid")"
     ccla_count="$(count_query reference-signature-index "signature_reference_id = :cid" \
@@ -113,7 +116,7 @@ do
       "signature_approved = :b AND signature_signed = :b" \
       "{\":cid\":{\"S\":\"${company_id}\"},\":b\":{\"BOOL\":true}}")"
 
-    echo -e "${company_id}\t${company_name}\t${signing_entity_name}\t${sfid}\t${status}\t${ccla_count}\t${ecla_count}"
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "${company_id}" "${company_name}" "${signing_entity_name}" "${sfid}" "${status}" "${ccla_count}" "${ecla_count}"
 
     { [ "$ccla_count" = "-1" ] || [ "$ecla_count" = "-1" ]; } && count_failures=$((count_failures + 1))
     total=$((total + 1))

--- a/utils/audit_company_reachability.sh
+++ b/utils/audit_company_reachability.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# Copyright The Linux Foundation and each contributor to CommunityBridge.
+# SPDX-License-Identifier: MIT
+
+# Audits companies-table reachability (#2054): classifies every cla-{STAGE}-companies row by
+# whether its company_external_id (SFID) is missing, resolves in the org-service, or no longer
+# does, and counts active (signed+approved) CCLAs/ECLAs per row so data fixes can be prioritized.
+# Tiers: MISSING_SFID | SFID_OK | SFID_DANGLING_OR_DELETED | UNKNOWN (org-service 404s both a
+# never-existed SFID and a soft-deleted SF Account, so those collapse into one tier).
+# TSV rows go to stdout ('#'-prefixed summary at the end), progress goes to stderr.
+# STAGE: dev (default) | test | staging | prod. AWS_REGION defaults to us-east-1.
+# TOKEN: optional bearer token for the org-service SFID liveness check - without it every row
+# that has an SFID is tiered UNKNOWN (only MISSING_SFID is authoritative in that mode).
+# SLEEP_S: optional seconds to sleep after each org-service call.
+# Usage: [STAGE=dev] [TOKEN=...] ./utils/audit_company_reachability.sh > companies_audit.tsv
+
+if [ -z "$STAGE" ]
+then
+  STAGE=dev
+fi
+if [ -z "$AWS_REGION" ]
+then
+  export AWS_REGION=us-east-1
+fi
+case "$STAGE" in
+  prod) GW="https://api-gw.platform.linuxfoundation.org" ;;
+  staging) GW="https://api-gw.staging.platform.linuxfoundation.org" ;;
+  test) GW="https://api-gw.test.platform.linuxfoundation.org" ;;
+  dev) GW="https://api-gw.dev.platform.linuxfoundation.org" ;;
+  *) echo "$0: unknown STAGE '$STAGE'" >&2; exit 2 ;;
+esac
+
+# Sums Count across query pages; the GSI queries mirror the production lookups:
+# CCLA = GetCompanySignatures (reference-signature-index), ECLA = the
+# signature-user-ccla-company-index partition (only ECLA rows carry that attribute).
+count_query () {
+  local index="$1" key_expr="$2" filter="$3" values="$4"
+  local total=0 lek="" page
+  while :
+  do
+    local args=(--profile "lfproduct-${STAGE}" dynamodb query --table-name "cla-${STAGE}-signatures" \
+      --index-name "$index" --key-condition-expression "$key_expr" \
+      --filter-expression "$filter" --expression-attribute-values "$values" --select COUNT)
+    [ -n "$lek" ] && args+=(--exclusive-start-key "$lek")
+    if ! page="$(aws "${args[@]}")"
+    then
+      echo "$0: signatures count query failed (index ${index}) - reporting -1 for this row" >&2
+      echo "-1"
+      return
+    fi
+    total=$((total + $(echo "$page" | jq -r '.Count // 0')))
+    lek="$(echo "$page" | jq -c '.LastEvaluatedKey // empty')"
+    [ -z "$lek" ] && break
+  done
+  echo "$total"
+}
+
+classify () {
+  local sfid="$1"
+  if [ -z "$sfid" ]
+  then
+    echo "MISSING_SFID"
+    return
+  fi
+  if [ -z "$TOKEN" ]
+  then
+    echo "UNKNOWN"
+    return
+  fi
+  local code
+  code="$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer ${TOKEN}" "${GW}/organization-service/v1/orgs/${sfid}")"
+  [ -n "$SLEEP_S" ] && sleep "$SLEEP_S"
+  case "$code" in
+    200) echo "SFID_OK" ;;
+    404) echo "SFID_DANGLING_OR_DELETED" ;;
+    *) echo "$0: org-service returned HTTP ${code} for SFID ${sfid}" >&2; echo "UNKNOWN" ;;
+  esac
+}
+
+echo -e "company_id\tcompany_name\tsigning_entity_name\tcompany_external_id\tsfid_status\tactive_ccla_count\tactive_ecla_count"
+
+total=0
+missing=0
+ok=0
+dangling=0
+unknown=0
+missing_with_active_ccla=0
+count_failures=0
+lek=""
+while :
+do
+  scan_args=(--profile "lfproduct-${STAGE}" dynamodb scan --table-name "cla-${STAGE}-companies" \
+    --projection-expression "company_id,company_name,signing_entity_name,company_external_id")
+  [ -n "$lek" ] && scan_args+=(--exclusive-start-key "$lek")
+  if ! scan_page="$(aws "${scan_args[@]}")"
+  then
+    echo "$0: companies scan failed" >&2
+    exit 3
+  fi
+  while IFS= read -r item
+  do
+    [ -z "$item" ] && continue
+    company_id="$(echo "$item" | jq -r '.company_id.S // ""')"
+    company_name="$(echo "$item" | jq -r '.company_name.S // ""')"
+    signing_entity_name="$(echo "$item" | jq -r '.signing_entity_name.S // ""')"
+    sfid="$(echo "$item" | jq -r '.company_external_id.S // ""')"
+
+    status="$(classify "$sfid")"
+    ccla_count="$(count_query reference-signature-index "signature_reference_id = :cid" \
+      "signature_type = :t AND signature_approved = :b AND signature_signed = :b" \
+      "{\":cid\":{\"S\":\"${company_id}\"},\":t\":{\"S\":\"ccla\"},\":b\":{\"BOOL\":true}}")"
+    ecla_count="$(count_query signature-user-ccla-company-index "signature_user_ccla_company_id = :cid" \
+      "signature_approved = :b AND signature_signed = :b" \
+      "{\":cid\":{\"S\":\"${company_id}\"},\":b\":{\"BOOL\":true}}")"
+
+    echo -e "${company_id}\t${company_name}\t${signing_entity_name}\t${sfid}\t${status}\t${ccla_count}\t${ecla_count}"
+
+    { [ "$ccla_count" = "-1" ] || [ "$ecla_count" = "-1" ]; } && count_failures=$((count_failures + 1))
+    total=$((total + 1))
+    case "$status" in
+      MISSING_SFID)
+        missing=$((missing + 1))
+        [ "$ccla_count" -gt 0 ] 2>/dev/null && missing_with_active_ccla=$((missing_with_active_ccla + 1))
+        ;;
+      SFID_OK) ok=$((ok + 1)) ;;
+      SFID_DANGLING_OR_DELETED) dangling=$((dangling + 1)) ;;
+      *) unknown=$((unknown + 1)) ;;
+    esac
+    if [ $((total % 100)) -eq 0 ]
+    then
+      echo "$0: processed ${total} companies..." >&2
+    fi
+  done < <(echo "$scan_page" | jq -c '.Items[]')
+  lek="$(echo "$scan_page" | jq -c '.LastEvaluatedKey // empty')"
+  [ -z "$lek" ] && break
+done
+
+echo "#"
+echo "# total companies scanned: ${total}"
+echo "# MISSING_SFID: ${missing} (of which with active CCLA: ${missing_with_active_ccla})"
+echo "# SFID_OK: ${ok}"
+if [ -z "$TOKEN" ]
+then
+  echo "# SFID_DANGLING_OR_DELETED: ${dangling} (TOKEN unset - liveness not checked)"
+  echo "# UNKNOWN: ${unknown} (TOKEN unset - every row with an SFID lands here)"
+else
+  echo "# SFID_DANGLING_OR_DELETED: ${dangling}"
+  echo "# UNKNOWN: ${unknown}"
+fi
+if [ "$count_failures" -gt 0 ]
+then
+  echo "# rows with FAILED signature count queries (-1 in TSV, excluded from the active-CCLA tally - re-run these): ${count_failures}"
+fi
+echo "# total unreachable (authoritative = MISSING_SFID + SFID_DANGLING_OR_DELETED): $((missing + dangling))"

--- a/utils/audit_company_reachability.sh
+++ b/utils/audit_company_reachability.sh
@@ -5,12 +5,14 @@
 # Audits companies-table reachability (#2054): classifies every cla-{STAGE}-companies row by
 # whether its company_external_id (SFID) is missing, resolves in the org-service, or no longer
 # does, and counts active (signed+approved) CCLAs/ECLAs per row so data fixes can be prioritized.
-# Tiers: MISSING_SFID | SFID_OK | SFID_DANGLING_OR_DELETED | UNKNOWN (org-service 404s both a
-# never-existed SFID and a soft-deleted SF Account, so those collapse into one tier).
+# Tiers: MISSING_SFID | INVALID_SFID_FORMAT | SFID_OK | SFID_DANGLING_OR_DELETED | UNKNOWN
+# (org-service 404s both a never-existed SFID and a soft-deleted SF Account, so those collapse
+# into one tier).
 # TSV rows go to stdout ('#'-prefixed summary at the end), progress goes to stderr.
 # STAGE: dev (default) | test | staging | prod. AWS_REGION defaults to us-east-1.
 # TOKEN: optional bearer token for the org-service SFID liveness check - without it every row
-# that has an SFID is tiered UNKNOWN (only MISSING_SFID is authoritative in that mode).
+# that has a valid-format SFID is tiered UNKNOWN (only MISSING_SFID and INVALID_SFID_FORMAT
+# are authoritative in that mode).
 # SLEEP_S: optional seconds to sleep after each org-service call.
 # Usage: [STAGE=dev] [TOKEN=...] ./utils/audit_company_reachability.sh > companies_audit.tsv
 
@@ -62,6 +64,14 @@ classify () {
     echo "MISSING_SFID"
     return
   fi
+  # the platform SFID rule from utils/v4/shared/validate_params.sh (validate_sfid), inlined to
+  # keep this script standalone; a malformed value would corrupt the org-service URL path and
+  # 404 as a false SFID_DANGLING_OR_DELETED
+  if ! [[ $sfid =~ ^[0-9A-Za-z]{15}$|^[0-9A-Za-z]{18}$ ]]
+  then
+    echo "INVALID_SFID_FORMAT"
+    return
+  fi
   if [ -z "$TOKEN" ]
   then
     echo "UNKNOWN"
@@ -81,10 +91,13 @@ printf 'company_id\tcompany_name\tsigning_entity_name\tcompany_external_id\tsfid
 
 total=0
 missing=0
+invalid=0
 ok=0
 dangling=0
 unknown=0
 missing_with_active_ccla=0
+invalid_with_active_ccla=0
+dangling_with_active_ccla=0
 count_failures=0
 lek=""
 while :
@@ -125,8 +138,15 @@ do
         missing=$((missing + 1))
         [ "$ccla_count" -gt 0 ] 2>/dev/null && missing_with_active_ccla=$((missing_with_active_ccla + 1))
         ;;
+      INVALID_SFID_FORMAT)
+        invalid=$((invalid + 1))
+        [ "$ccla_count" -gt 0 ] 2>/dev/null && invalid_with_active_ccla=$((invalid_with_active_ccla + 1))
+        ;;
       SFID_OK) ok=$((ok + 1)) ;;
-      SFID_DANGLING_OR_DELETED) dangling=$((dangling + 1)) ;;
+      SFID_DANGLING_OR_DELETED)
+        dangling=$((dangling + 1))
+        [ "$ccla_count" -gt 0 ] 2>/dev/null && dangling_with_active_ccla=$((dangling_with_active_ccla + 1))
+        ;;
       *) unknown=$((unknown + 1)) ;;
     esac
     if [ $((total % 100)) -eq 0 ]
@@ -141,17 +161,18 @@ done
 echo "#"
 echo "# total companies scanned: ${total}"
 echo "# MISSING_SFID: ${missing} (of which with active CCLA: ${missing_with_active_ccla})"
+echo "# INVALID_SFID_FORMAT: ${invalid} (of which with active CCLA: ${invalid_with_active_ccla})"
 echo "# SFID_OK: ${ok}"
 if [ -z "$TOKEN" ]
 then
   echo "# SFID_DANGLING_OR_DELETED: ${dangling} (TOKEN unset - liveness not checked)"
-  echo "# UNKNOWN: ${unknown} (TOKEN unset - every row with an SFID lands here)"
+  echo "# UNKNOWN: ${unknown} (TOKEN unset - every row with a valid-format SFID lands here)"
 else
-  echo "# SFID_DANGLING_OR_DELETED: ${dangling}"
+  echo "# SFID_DANGLING_OR_DELETED: ${dangling} (of which with active CCLA: ${dangling_with_active_ccla})"
   echo "# UNKNOWN: ${unknown}"
 fi
 if [ "$count_failures" -gt 0 ]
 then
   echo "# rows with FAILED signature count queries (-1 in TSV, excluded from the active-CCLA tally - re-run these): ${count_failures}"
 fi
-echo "# total unreachable (authoritative = MISSING_SFID + SFID_DANGLING_OR_DELETED): $((missing + dangling))"
+echo "# total unreachable (authoritative = MISSING_SFID + INVALID_SFID_FORMAT + SFID_DANGLING_OR_DELETED): $((missing + invalid + dangling)) (of which with active CCLA: $((missing_with_active_ccla + invalid_with_active_ccla + dangling_with_active_ccla)))"


### PR DESCRIPTION
This is for:
- https://github.com/linuxfoundation/lfx-self-serve/issues/2043 (umbrella).
- https://github.com/linuxfoundation/lfx-self-serve/issues/2054 (EasyCLA companies unreachable from the org lens: missing or invalid Salesforce SFID) - only audit work `utils/audit_company_reachability.sh` - data backfill is a separate story (can be done manually).
- https://github.com/linuxfoundation/lfx-self-serve/issues/2055 (retires unused endpoint).
- https://github.com/linuxfoundation/lfx-self-serve/issues/2056 (Duplicate company rows per SFID break org-lens company resolution).

M3 completeness audit — #2043.

Should go after #5198 which also includes fix for https://github.com/linuxfoundation/lfx-self-serve/issues/2186 (not covered here).

Signed-off-by: Łukasz Gryglicki <lgryglicki@cncf.io>

Assisted by [OpenAI](https://platform.openai.com/)

Assisted by [GitHub Copilot](https://github.com/features/copilot)

Assisted by [Claude](https://claude.ai)