### PR TITLE
feat(company): add approvalCriteriaCount to the org CLA posture endpoint

### DIFF
--- a/cla-backend-go/swagger/common/company-cla-group.yaml
+++ b/cla-backend-go/swagger/common/company-cla-group.yaml
@@ -65,6 +65,15 @@ properties:
     format: int64
     x-omitempty: false
     description: Number of employee acknowledgements (ECLAs) under this CCLA
+  approvalCriteriaCount:
+    type: integer
+    format: int64
+    x-omitempty: false
+    description: >-
+      Number of approval criteria entries on the CCLA, summed across all six lists
+      (email, email domain, GitHub username, GitHub org, GitLab username, GitLab group).
+      These are rules granting coverage, not people - one domain rule can cover a whole
+      company, so this is unrelated to approvedContributorsCount
   claManagersCount:
     type: integer
     format: int64

--- a/cla-backend-go/v2/company/service.go
+++ b/cla-backend-go/v2/company/service.go
@@ -1410,6 +1410,7 @@ func (s *service) GetCompanyClaGroups(ctx context.Context, companySFID string) (
 			})
 			row.ClaManagersCount = int64(len(row.ClaManagers))
 			row.NeedsClaManager = row.Signed && row.ClaManagersCount == 0
+			row.ApprovalCriteriaCount = approvalCriteriaCount(sig)
 			contributors, eclaErr := s.signatureRepo.GetClaGroupCorporateContributors(ctx, claGroupID, &comp.CompanyID, aws.Int64(1), nil, nil)
 			if eclaErr != nil {
 				return nil, eclaErr
@@ -1451,6 +1452,18 @@ func (s *service) getCompanyCCLASignaturesWithACL(ctx context.Context, companyID
 		lastScannedKey = aws.String(sigModels.LastKeyScanned)
 	}
 	return sigs, nil
+}
+
+// approvalCriteriaCount totals the approval rules on a CCLA across all six criteria lists.
+// Relies on the signature having been loaded with the full projection, which is the only
+// one carrying the approval-list columns.
+func approvalCriteriaCount(sig *v1Models.Signature) int64 {
+	return int64(len(sig.EmailApprovalList) +
+		len(sig.DomainApprovalList) +
+		len(sig.GithubUsernameApprovalList) +
+		len(sig.GithubOrgApprovalList) +
+		len(sig.GitlabUsernameApprovalList) +
+		len(sig.GitlabOrgApprovalList))
 }
 
 func newerSignature(a, b *v1Models.Signature) bool {

--- a/cla-backend-go/v2/company/service_test.go
+++ b/cla-backend-go/v2/company/service_test.go
@@ -242,6 +242,9 @@ func TestGetCompanyClaGroups(t *testing.T) {
 					{UserID: "user-id-bob", LfUsername: "bob"},
 					{UserID: "user-id-alice", LfUsername: "alice"},
 				},
+				DomainApprovalList:         []string{"acme.example"},
+				GithubOrgApprovalList:      []string{"acme-oss", "acme-labs"},
+				GitlabUsernameApprovalList: []string{"acme-dev"},
 			},
 		},
 	}, nil)
@@ -312,6 +315,7 @@ func TestGetCompanyClaGroups(t *testing.T) {
 	assert.Equal(t, "signature-id-1", first.SignatureID)
 	assert.False(t, first.Sanctioned)
 	assert.Equal(t, int64(3), first.ApprovedContributorsCount)
+	assert.Equal(t, int64(4), first.ApprovalCriteriaCount)
 	assert.Equal(t, int64(2), first.ClaManagersCount)
 	assert.Equal(t, []models.CompanyClaGroupManager{
 		{UserID: "user-id-alice", LfUsername: "alice"},
@@ -327,9 +331,49 @@ func TestGetCompanyClaGroups(t *testing.T) {
 	assert.Equal(t, "2023-05-06T07:08:09Z", second.SignedOn)
 	assert.True(t, second.Sanctioned)
 	assert.Equal(t, int64(0), second.ApprovedContributorsCount)
+	assert.Equal(t, int64(0), second.ApprovalCriteriaCount)
 	assert.Equal(t, int64(0), second.ClaManagersCount)
 	assert.True(t, second.NeedsClaManager)
 	assert.False(t, second.AutoCreateECLA)
+}
+
+func TestApprovalCriteriaCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		sig      *v1Models.Signature
+		expected int64
+	}{
+		{
+			name:     "no approval lists",
+			sig:      &v1Models.Signature{},
+			expected: 0,
+		},
+		{
+			name: "all six lists contribute",
+			sig: &v1Models.Signature{
+				EmailApprovalList:          []string{"dev@acme.example"},
+				DomainApprovalList:         []string{"acme.example", "acme.test"},
+				GithubUsernameApprovalList: []string{"acme-dev", "acme-ops", "acme-qa"},
+				GithubOrgApprovalList:      []string{"acme-oss"},
+				GitlabUsernameApprovalList: []string{"acme-gl-dev", "acme-gl-ops"},
+				GitlabOrgApprovalList:      []string{"acme-gl"},
+			},
+			expected: 10,
+		},
+		{
+			name: "a single domain rule counts once regardless of who it covers",
+			sig: &v1Models.Signature{
+				DomainApprovalList: []string{"acme.example"},
+			},
+			expected: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, approvalCriteriaCount(tt.sig))
+		})
+	}
 }
 
 func TestGetCompanyClaGroupsCompanyNotFound(t *testing.T) {
@@ -547,7 +591,7 @@ func TestNewerSignature(t *testing.T) {
 func TestCompanyClaGroupsJSONContract(t *testing.T) {
 	b, err := json.Marshal(models.CompanyClaGroup{})
 	assert.Nil(t, err)
-	for _, key := range []string{"companyID", "companySFID", "companyName", "signingEntityName", "claGroupID", "claGroupName", "foundationSFID", "foundationName", "projects", "signed", "signedOn", "signatureID", "sanctioned", "approvedContributorsCount", "claManagersCount", "claManagers", "needsClaManager", "autoCreateECLA"} {
+	for _, key := range []string{"companyID", "companySFID", "companyName", "signingEntityName", "claGroupID", "claGroupName", "foundationSFID", "foundationName", "projects", "signed", "signedOn", "signatureID", "sanctioned", "approvedContributorsCount", "approvalCriteriaCount", "claManagersCount", "claManagers", "needsClaManager", "autoCreateECLA"} {
 		assert.Contains(t, string(b), fmt.Sprintf("%q:", key))
 	}
 

--- a/docs/M3_ORG_LENS_API.md
+++ b/docs/M3_ORG_LENS_API.md
@@ -23,8 +23,15 @@ carrying the given external `companySFID`. Each entry carries all its ids
 `signingEntityName`, `claGroupName`, `foundationName`, the covered `projects`,
 `signed`/`signedOn`, the stored `sanctioned` flag, `approvedContributorsCount` (employee
 acknowledgements under the CCLA, same count as the corporate-console contributors list),
-`claManagers` (from the signature ACL) with `claManagersCount`,
+`approvalCriteriaCount`, `claManagers` (from the signature ACL) with `claManagersCount`,
 `needsClaManager` (= signed with zero managers) and `autoCreateECLA`.
+
+`approvalCriteriaCount` ([lfx-self-serve#2222](https://github.com/linuxfoundation/lfx-self-serve/issues/2222))
+sums the CCLA's six approval lists (email, email domain, GitHub username, GitHub org,
+GitLab username, GitLab group) off the signature already loaded for this response, so it
+costs no extra query. It counts **rules**, not people, and is therefore unrelated to
+`approvedContributorsCount` — one domain rule can cover an entire company. The Org Lens
+CLA Group card renders it as its own stat alongside `claManagersCount`.
 
 An unknown company or a company with no CCLAs returns HTTP 200 with an empty `list` —
 the endpoint never auto-creates the company record. Auth: LF admin, `organization`


### PR DESCRIPTION
Adds `approvalCriteriaCount` to `GET /v4/company/external/{companySFID}/cla-groups`:
the total approval-criteria entries on the CCLA across all six lists. The six lists are
already on the signature this handler loads, so the count is summed in place and costs
no extra query. Additive and read-only.

Refs linuxfoundation/lfx-self-serve#2222